### PR TITLE
[Fixes #167918734] Added code to catch non-alnum keycodes in select

### DIFF
--- a/client/src/pages/AuthorisationGroup.jsx
+++ b/client/src/pages/AuthorisationGroup.jsx
@@ -274,18 +274,20 @@ class AuthorisationGroup extends React.Component {
     };
 
     addService = option => {
-        const {collaboration, authorisationGroup, name} = this.state;
-        const authorisationGroupName = isEmpty(authorisationGroup) ? name : authorisationGroup.name;
-        addAuthorisationGroupServices({
-            authorisationGroupId: authorisationGroup.id,
-            collaborationId: collaboration.id,
-            serviceIds: option.value
-        }).then(() => {
-            this.refreshServices(() => setFlash(I18n.t("authorisationGroup.flash.addedService", {
-                service: option.label,
-                name: authorisationGroupName
-            })));
-        });
+        if(option) {
+            const {collaboration, authorisationGroup, name} = this.state;
+            const authorisationGroupName = isEmpty(authorisationGroup) ? name : authorisationGroup.name;
+            addAuthorisationGroupServices({
+                authorisationGroupId: authorisationGroup.id,
+                collaborationId: collaboration.id,
+                serviceIds: option.value
+            }).then(() => {
+                this.refreshServices(() => setFlash(I18n.t("authorisationGroup.flash.addedService", {
+                    service: option.label,
+                    name: authorisationGroupName
+                })));
+            });
+        }
     };
 
     userServiceProfileContainsPersonalData = userServiceProfile => {
@@ -326,6 +328,12 @@ class AuthorisationGroup extends React.Component {
                 name: authorisationGroupName
             })));
         });
+    };
+
+    addMemberOrInvitation = option => {
+        if(option) {
+            option.isMember ? this.addMember(option) : this.addInvitation(option);
+        }
     };
 
     addMember = option => {
@@ -684,7 +692,7 @@ class AuthorisationGroup extends React.Component {
             <div className={`authorisation-members ${adminOfCollaboration ? "" : "no-admin"}`}>
                 {adminOfCollaboration && <Select className="services-select"
                                                  placeholder={I18n.t("authorisationGroup.searchMembers", {name: authorisationGroupName})}
-                                                 onChange={option => option.isMember ? this.addMember(option) : this.addInvitation(option)}
+                                                 onChange={this.addMemberOrInvitation}
                                                  options={availableOptions}
                                                  value={null}
                                                  isSearchable={true}

--- a/client/src/pages/CollaborationServices.jsx
+++ b/client/src/pages/CollaborationServices.jsx
@@ -68,13 +68,15 @@ class CollaborationServices extends React.Component {
     };
 
     addService = option => {
-        const {collaboration} = this.state;
-        addCollaborationServices({collaborationId: collaboration.id, serviceIds: option.value}).then(() => {
-            this.refresh(() => setFlash(I18n.t("collaborationServices.flash.added", {
-                service: option.label,
-                name: collaboration.name
-            })));
-        });
+        if(option) {
+            const {collaboration} = this.state;
+            addCollaborationServices({collaborationId: collaboration.id, serviceIds: option.value}).then(() => {
+                this.refresh(() => setFlash(I18n.t("collaborationServices.flash.added", {
+                    service: option.label,
+                    name: collaboration.name
+                })));
+            });
+        }
     };
 
     removeService = service => e => {
@@ -147,7 +149,7 @@ class CollaborationServices extends React.Component {
             return null;
         }
         const availableServices = allServices.filter(service => !sortedServices.find(s => s.id === service.value));
-        //TODO render an explanation info which explains the purpose ot the page. preferably inline like was done with teams
+        //TODO render an explanation info which explains the purpose of the page. preferably inline like was done with teams
         return (
             <div className="mod-collaboration-services">
                 <div className="title">


### PR DESCRIPTION
There are a number of different solutions used to select various sub-objects. This fix adds an additional check to the occurances of an editable-select option to avoid errors in case of using a backspace key or something similar. 
Other occurances use an input with onkeydown, which properly guards the input. Or they do not allow editable inputs, which blocks out backspace keys.
Apparently this PR does not fix everything: there is a report on a similar error on a input-field-with-keydown-solution, but I could not reproduce that.