### PR TITLE
[Fixes #168750347] Fixes for 404 response on declining invitations

### DIFF
--- a/client/src/pages/Invitation.jsx
+++ b/client/src/pages/Invitation.jsx
@@ -70,7 +70,16 @@ class Invitation extends React.Component {
     closeConfirmationDialog = () => this.setState({confirmationDialogOpen: false});
 
     gotoCollaborations = () => this.setState({confirmationDialogOpen: false},
-        () => this.props.history.push(`/collaborations/${this.state.invite.collaboration.id}`));
+        () => {
+            const {invite} = this.state;
+            const member = (this.props.user.collaboration_memberships || []).find(membership => membership.collaboration_id === this.state.invite.collaboration.id);
+            if (member) {
+                this.props.history.push(`/collaborations/${this.state.invite.collaboration.id}`);
+            }
+            else {
+                this.props.history.push(`/home`);
+            }
+        });
 
     cancel = () => {
         this.setState({

--- a/client/src/pages/OrganisationDetail.jsx
+++ b/client/src/pages/OrganisationDetail.jsx
@@ -69,6 +69,11 @@ class OrganisationDetail extends React.Component {
                     } = this.state;
                     const members = sortObjects(json.organisation_memberships, sorted, reverse);
                     const collaborations = sortObjects(json.collaborations, sortedCollaborationAttribute, reverseCollaborationSorted);
+                    const member = (user.organisation_memberships || []).find(membership => membership.organisation_id === json.id);
+                    if (isEmpty(member) && !user.admin) {
+                        this.props.history.push("/404");
+                        return;
+                    }
                     this.setState({
                         originalOrganisation: json,
                         name: json.name,
@@ -82,6 +87,9 @@ class OrganisationDetail extends React.Component {
                         adminOfOrganisation: json.organisation_memberships.some(member => member.role === "admin" && member.user_id === user.id),
                         apiKeys: json.api_keys
                     })
+                }, () => {
+                    this.props.history.push("/404");
+                    return;
                 });
         } else {
             this.props.history.push("/404");

--- a/client/src/pages/OrganisationInvitation.jsx
+++ b/client/src/pages/OrganisationInvitation.jsx
@@ -62,7 +62,19 @@ class OrganisationInvitation extends React.Component {
     closeConfirmationDialog = () => this.setState({confirmationDialogOpen: false});
 
     gotoOrganisations = () => this.setState({confirmationDialogOpen: false},
-        () => this.props.history.push(`/organisations/${this.state.organisationInvitation.organisation.id}`));
+        () => {
+            const {invite} = this.state;
+            const member = (this.props.user.organisation_memberships || []).find(membership => membership.organisation_id === this.state.organisationInvitation.organisation.id);
+            if (member) {
+                this.props.history.push(`/organisations/${this.state.organisationInvitation.organisation.id}`);
+            }
+            else if(this.props.user.organisation_memberships.length) {
+                this.props.history.push(`/organisations`);
+            }
+            else {
+                this.props.history.push(`/home`);
+            }
+        });
 
     cancel = () => {
         this.setState({


### PR DESCRIPTION
Added a 404 response to OrganisationDetail like what was implemented in CollaborationDetail. This will cause an error when visiting a page like /organisations/does-not-exist
Then added code to determine collaboration/organisation membership before redirecting users to a detail, overview or home page. This routine is called when an invite is declined, in which case the current user probably is not a member of the current collaboration or organisation and the only sensible route is the home page.
When the user is a member of another organisation, declining the organisation invite will result in redirection to /organisations
This was not implemented similarly for collaborations, because regular non-admin users do not have access to the /collaborations overview page, so /home seemed the only sensible page.