### PR TITLE
fixes rondom attribuut mapping

### DIFF
--- a/server/api/user.py
+++ b/server/api/user.py
@@ -209,6 +209,8 @@ def resume_session():
         logger.error(error_msg)
         return redirect(f"{current_app.app_config.base_url}/error")
 
+    logger.debug(f"Fetched userinfo: {response.text}")
+
     user_info_json = response.json()
     uid = user_info_json["sub"]
     user = User.query.filter(User.uid == uid).first()

--- a/server/auth/user_claims.py
+++ b/server/auth/user_claims.py
@@ -57,8 +57,8 @@ def add_user_claims(user_info_json, uid, user, replace_none_values=True):
     for claim in claim_attribute_mapping():
         for key, attr in claim.items():
             val = user_info_json.get(key)
-            if val and isinstance(val, list):
-                val = ", ".join(val)
+            if isinstance(val, list):
+                val = ", ".join(val) if val else None
             if val or replace_none_values:
                 setattr(user, attr, val)
     if not user.name:

--- a/server/auth/user_claims.py
+++ b/server/auth/user_claims.py
@@ -18,8 +18,8 @@ def claim_attribute_mapping():
             {"given_name": "given_name"},
             {"family_name": "family_name"},
             {"email": "email"},
-            {"eduperson_scoped_affiliation": "scoped_affiliation"},
-            {"voperson_external_affiliation": "affiliation"},
+            {"eduperson_scoped_affiliation": "affiliation"},
+            {"voperson_external_affiliation": "scoped_affiliation"},
             {"eduperson_entitlement": "entitlement"},
             {"eduperson_principal_name": "eduperson_principal_name"}
         ]

--- a/server/auth/user_claims.py
+++ b/server/auth/user_claims.py
@@ -33,7 +33,7 @@ def _normalize(s):
     return re.sub("[^a-zA-Z0-9_]", "", normalized)
 
 
-def generate_unique_username(user: User, user_info_json = {}, max_count=10000):
+def generate_unique_username(user: User, user_info_json={}, max_count=10000):
     """
     # TODO: clean up this mess with mismatching attributes and field names
     if hasattr(user, "eduperson_principal_name") and user.eduperson_principal_name:

--- a/server/auth/user_claims.py
+++ b/server/auth/user_claims.py
@@ -30,7 +30,7 @@ def _normalize(s):
     if s is None:
         return ""
     normalized = unicodedata.normalize("NFKD", s).encode("ascii", "ignore").decode("utf-8").strip()
-    return re.sub("[^a-zA-Z]", "", normalized)
+    return re.sub("[^a-z0-9_]", "", normalized)
 
 
 def generate_unique_username(user: User, max_count=10000):

--- a/server/auth/user_claims.py
+++ b/server/auth/user_claims.py
@@ -30,7 +30,7 @@ def _normalize(s):
     if s is None:
         return ""
     normalized = unicodedata.normalize("NFKD", s).encode("ascii", "ignore").decode("utf-8").strip()
-    return re.sub("[^a-z0-9_]", "", normalized)
+    return re.sub("[^a-zA-Z0-9_]", "", normalized)
 
 
 def generate_unique_username(user: User, max_count=10000):

--- a/server/test/auth/test_user_claims.py
+++ b/server/test/auth/test_user_claims.py
@@ -31,6 +31,11 @@ class TestUserClaims(AbstractTest):
         add_user_claims({"voperson_external_id": "university"}, "urn:johny", user)
         self.assertEqual("university", user.schac_home_organisation)
 
+    def test_add_user_claims_empty_entitlements(self):
+        user = User()
+        add_user_claims({"eduperson_entitlement": []}, "urn:johny", user)
+        self.assertIsNone(user.entitlement)
+
     def test_add_user_claims_user_name(self):
         user = User()
         add_user_claims({"given_name": "John", "family_name": "Doe"}, "urn:johny", user)

--- a/server/test/auth/test_user_claims.py
+++ b/server/test/auth/test_user_claims.py
@@ -47,6 +47,18 @@ class TestUserClaims(AbstractTest):
                          "eduperson_principal_name": "mettens@example.com.org"}, "urn:johny", user)
         self.assertEqual("mettens", user.username)
 
+    def test_add_user_claims_user_name_eduperson_principal_name_numbers(self):
+        user = User()
+        add_user_claims({"given_name": "John", "family_name": "Doe",
+                         "eduperson_principal_name": "mettens123@example.com.org"}, "urn:johny", user)
+        self.assertEqual("mettens123", user.username)
+
+    def test_add_user_claims_user_name_eduperson_principal_name_invalid_chars(self):
+        user = User()
+        add_user_claims({"given_name": "John", "family_name": "Doe",
+                         "eduperson_principal_name": "髙-pieß-!t@#-髙x@example.com.org"}, "urn:johny", user)
+        self.assertEqual("piet", user.username)
+
     def test_generate_unique_username(self):
         # we don't want this in the normal seed
         for username in ["jdoe", "jdoe2", "cdoemanchi", "cdoemanchi2", "cdoemanchi3", "u", "u2"]:

--- a/server/test/auth/test_user_claims.py
+++ b/server/test/auth/test_user_claims.py
@@ -70,10 +70,5 @@ class TestUserClaims(AbstractTest):
         self.assertListEqual(["jdoe3", "cdoemanchi4", "u3", "paa"], short_names)
 
     def test_generate_unique_username_random(self):
-        username = generate_unique_username(munchify({"given_name": "John", "family_name": "Doe"}), 1)
+        username = generate_unique_username(munchify({"given_name": "John", "family_name": "Doe"}), max_count=1)
         self.assertEqual(14, len(username))
-
-    def test_eppn_generate_unique_username(self):
-        user = User(eduperson_principal_name="sarah-lee")
-        username = generate_unique_username(user)
-        self.assertEqual("sarahlee", username)


### PR DESCRIPTION
Hoi Okke,

Ik heb tegen de oude versie van SBS (pre-redesign) een paar fixes gemaakt omdat de attribuut mapping nog niet helemaal klopte.  De aangepaste mapping is triviaal, maar dit heeft wel als sideeffect dat de oidc claim die we gebruikten om de username van af te leiden (`eduperson_principal_name`) niet meer beschikbaar is als field van `User` (daar mapt nu `voperson_external_id` op `User.eduperson_principal_name`).  Daarom heb ik nog een andere kunstgreep moeten uithalen in de username generatie.

Anyway, deze PR is vooral een beetje ter referentie en niet om as-is te mergen.
Ik denk dat we even goed moeten nadenken hoe we dit structureel willen oplossen.  Wellicht is het bv beter om alle OIDC claim in 1 databasekolom te stoppen, zodat we alles beschikbaar hebben.  En verder is het om verwarring te voorkomen wellicht handig om een aantal van de fields van User te renamen.

Laten we hier binnenkort even over overleggen.