### PR TITLE
Upgrade to backward-incompatible SQLAlchemy 2.X

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,7 @@ jobs:
       #- name: Setup tmate session
         #uses: mxschmitt/action-tmate@v3
 
-      - name: Run tests
+      - name: Run flake8
         run: |
           flake8 ./server/
 

--- a/README.md
+++ b/README.md
@@ -75,12 +75,12 @@ CONFIG='config/test_config.yml' FLASK_APP='__main__.py' flask routes
 
 To run all Python tests and validate syntax / formatting:
 ```
-pytest --disable-warnings server/test
+pytest server/test
 flake8 ./server/
 ```
 To generate coverage reports:
 ```
-pytest --disable-warnings --cov=server --cov-report html:htmlcov server/test
+pytest --cov=server --cov-report html:htmlcov server/test
 open htmlcov/index.html
 ```
 To run all JavaScript tests:

--- a/server/api/organisation.py
+++ b/server/api/organisation.py
@@ -130,6 +130,7 @@ def organisation_by_id(organisation_id):
         if not is_admin:
             user_id = current_user_id()
             query = query \
+                .join(Organisation.organisation_memberships) \
                 .join(OrganisationMembership.user) \
                 .filter(OrganisationMembership.role.in_(["admin", "manager"])) \
                 .filter(OrganisationMembership.user_id == user_id)

--- a/server/api/user.py
+++ b/server/api/user.py
@@ -375,7 +375,7 @@ def attribute_aggregation():
         .join(User.collaboration_memberships) \
         .join(CollaborationMembership.collaboration) \
         .options(selectinload(User.collaboration_memberships)
-                 .contains_eager(CollaborationMembership.collaboration)) \
+                 .selectinload(CollaborationMembership.collaboration)) \
         .filter(or_(User.uid == edu_person_principal_name,
                     User.email == email)) \
         .all()

--- a/server/db/domain.py
+++ b/server/db/domain.py
@@ -169,10 +169,12 @@ class Collaboration(Base, db.Model):
     website_url = db.Column("website_url", db.String(length=512), nullable=True)
     invitations_count = column_property(select([func.count(Invitation.id)])
                                         .where(Invitation.collaboration_id == id)
-                                        .correlate_except(Invitation))
+                                        .correlate_except(Invitation)
+                                        .scalar_subquery())
     collaboration_memberships_count = column_property(select([func.count(CollaborationMembership.id)])
                                                       .where(CollaborationMembership.collaboration_id == id)
-                                                      .correlate_except(CollaborationMembership))
+                                                      .correlate_except(CollaborationMembership)
+                                                      .scalar_subquery())
 
     def is_member(self, user_id):
         return len(list(filter(lambda membership: membership.user_id == user_id, self.collaboration_memberships))) > 0
@@ -234,10 +236,12 @@ class Organisation(Base, db.Model):
                                passive_deletes=True)
     collaborations_count = column_property(select([func.count(Collaboration.id)])
                                            .where(Collaboration.organisation_id == id)
-                                           .correlate_except(Collaboration))
+                                           .correlate_except(Collaboration)
+                                           .scalar_subquery())
     organisation_memberships_count = column_property(select([func.count(OrganisationMembership.id)])
                                                      .where(OrganisationMembership.organisation_id == id)
-                                                     .correlate_except(OrganisationMembership))
+                                                     .correlate_except(OrganisationMembership)
+                                                     .scalar_subquery())
 
     def is_member(self, user_id):
         return len(list(filter(lambda membership: membership.user_id == user_id, self.organisation_memberships))) > 0

--- a/server/db/domain.py
+++ b/server/db/domain.py
@@ -110,9 +110,8 @@ class Invitation(Base, db.Model):
     collaboration = db.relationship("Collaboration", back_populates="invitations")
     user_id = db.Column(db.Integer(), db.ForeignKey("users.id"))
     user = db.relationship("User")
-    groups = db.relationship("Group",
-                             secondary=groups_invitations_association,
-                             lazy="select")
+    groups = db.relationship("Group", secondary=groups_invitations_association, lazy="select",
+                             back_populates="invitations")
     accepted = db.Column("accepted", db.Boolean(), nullable=True)
     denied = db.Column("denied", db.Boolean(), nullable=True)
     intended_role = db.Column("intended_role", db.String(length=255), nullable=True)
@@ -152,7 +151,8 @@ class Collaboration(Base, db.Model):
     updated_by = db.Column("updated_by", db.String(length=512), nullable=False)
     created_at = db.Column("created_at", db.DateTime(timezone=True), server_default=db.text("CURRENT_TIMESTAMP"),
                            nullable=False)
-    services = db.relationship("Service", secondary=services_collaborations_association, lazy="select")
+    services = db.relationship("Service", secondary=services_collaborations_association, lazy="select",
+                               back_populates="collaborations")
     collaboration_memberships = db.relationship("CollaborationMembership", back_populates="collaboration",
                                                 cascade="all, delete-orphan", passive_deletes=True)
     groups = db.relationship("Group", back_populates="collaboration",
@@ -219,7 +219,8 @@ class Organisation(Base, db.Model):
                                                default=False)
     collaborations = db.relationship("Collaboration", back_populates="organisation", cascade="all, delete-orphan",
                                      passive_deletes=True)
-    services = db.relationship("Service", secondary=services_organisations_association, lazy="select")
+    services = db.relationship("Service", secondary=services_organisations_association, lazy="select",
+                               back_populates="organisations")
     collaboration_requests = db.relationship("CollaborationRequest", back_populates="organisation",
                                              cascade="all, delete-orphan",
                                              passive_deletes=True)
@@ -263,9 +264,11 @@ class Service(Base, db.Model):
                                                default=False)
     code_of_conduct_compliant = db.Column("code_of_conduct_compliant", db.Boolean(), nullable=True, default=False)
     sirtfi_compliant = db.Column("sirtfi_compliant", db.Boolean(), nullable=True, default=False)
-    collaborations = db.relationship("Collaboration", secondary=services_collaborations_association, lazy="select")
+    collaborations = db.relationship("Collaboration", secondary=services_collaborations_association, lazy="select",
+                                     back_populates="services")
     allowed_organisations = db.relationship("Organisation", secondary=organisations_services_association, lazy="select")
-    organisations = db.relationship("Organisation", secondary=services_organisations_association, lazy="select")
+    organisations = db.relationship("Organisation", secondary=services_organisations_association, lazy="select",
+                                    back_populates="services")
     ip_networks = db.relationship("IpNetwork", cascade="all, delete-orphan", passive_deletes=True)
     service_connection_requests = db.relationship("ServiceConnectionRequest", back_populates="service",
                                                   cascade="all, delete-orphan", passive_deletes=True)
@@ -290,7 +293,8 @@ class Group(Base, db.Model):
                                                 secondary=collaboration_memberships_groups_association,
                                                 back_populates="groups",
                                                 lazy="select")
-    invitations = db.relationship("Invitation", secondary=groups_invitations_association, lazy="select")
+    invitations = db.relationship("Invitation", secondary=groups_invitations_association, lazy="select",
+                                  back_populates="groups")
     created_by = db.Column("created_by", db.String(length=512), nullable=False)
     updated_by = db.Column("updated_by", db.String(length=512), nullable=False)
     created_at = db.Column("created_at", db.DateTime(timezone=True), server_default=db.text("CURRENT_TIMESTAMP"),

--- a/server/requirements/base.txt
+++ b/server/requirements/base.txt
@@ -1,7 +1,7 @@
 APScheduler==3.6.3
 PyMySQL==0.10.1
 PyYAML==5.3.1
-SQLAlchemy<1.4
+SQLAlchemy==1.4.2
 Werkzeug~=1.0.1
 cryptography==3.3.2
 flask-jsonschema-validator==0.0.4
@@ -9,6 +9,7 @@ flask-mail==0.9.1
 flask==1.1.2
 flask_jsontools==0.1.7
 flask_migrate==2.7.0
+Flask-SQLAlchemy==2.5.1
 future_fstrings==1.2.0
 jinja2==2.11.3
 munch==2.5.0

--- a/server/requirements/test.txt
+++ b/server/requirements/test.txt
@@ -1,9 +1,9 @@
 -r base.txt
 blinker==1.4
-flake8==3.8.4
-flask-testing==0.8.0
+flake8==3.9.0
+flask-testing==0.8.1
 flask-webtest==0.0.9
 hbmqtt2==0.9.7
-pytest-cov==2.10.1
-pytest==6.1.1
-responses==0.12.0
+pytest-cov==2.11.1
+pytest==6.2.2
+responses==0.13.1

--- a/server/test/api/test_audit_log.py
+++ b/server/test/api/test_audit_log.py
@@ -42,7 +42,7 @@ class TestAuditLog(AbstractTest):
 
         state_after = json.loads(audit_logs[1]["state_after"])
 
-        self.assertEquals(state_after["ssh_key"], "ssh_value")
+        self.assertEqual(state_after["ssh_key"], "ssh_value")
 
     def test_services_info(self):
         self.login("urn:john")

--- a/server/test/api/test_user.py
+++ b/server/test/api/test_user.py
@@ -39,7 +39,7 @@ class TestUser(AbstractTest):
     def test_me_user_with_suspend_notifactions(self):
         self.login("urn:two_suspend")
         res = self.client.get("/api/users/me")
-        self.assertEquals(True, res.json["successfully_activated"])
+        self.assertEqual(True, res.json["successfully_activated"])
 
     def test_me_user_with_collaboration_requests(self):
         self.login("urn:peter")

--- a/server/test/seed.py
+++ b/server/test/seed.py
@@ -282,7 +282,6 @@ def seed(db, app_config):
 
     uuc.services.append(uuc_scheduler)
     uuc.services.append(wiki)
-    db.session.merge(uuc)
 
     ai_computing = Collaboration(name=ai_computing_name,
                                  identifier=collaboration_ai_computing_uuid,
@@ -369,8 +368,6 @@ def seed(db, app_config):
                           collaboration=uva_research,
                           collaboration_memberships=[roger_uva_research])
     _persist(db, group_researchers, group_developers, group_science)
-
-    db.session.commit()
 
     join_request_john = JoinRequest(message="Please...", reference=join_request_reference, user=john,
                                     collaboration=ai_computing, hash=token_urlsafe(), status="open")


### PR DESCRIPTION
The inner DSL has changed and the auto-commit behaviour. See
https://docs.sqlalchemy.org/en/14/changelog/migration_20.html

All tests are green again after changing the commit calls in the seed
and a refactoring of the models.py which validated, saves, updates and
deletes entries in a generic way.

But the whole app needs to be tested when deployed as this is a major
change.