### PR TITLE
Serve logo-urls instead of the encoded image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,18 @@ jobs:
         ports:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
-
+      redis:
+        # Docker Hub image
+        image: redis
+        # Set health checks to wait until redis has started
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          # Maps port 6379 on service container to the host
+          - 6379:6379
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: 'python'
 
 services:
   - 'mysql'
+  - 'redis'
 
 dist: xenial
 

--- a/client/src/components/redesign/CroppedImageDialog.jsx
+++ b/client/src/components/redesign/CroppedImageDialog.jsx
@@ -10,6 +10,7 @@ import ReactCrop from "react-image-crop";
 import ErrorIndicator from "./ErrorIndicator";
 import CheckBox from "../CheckBox";
 import {sanitizeHtml} from "../../utils/Markdown";
+import {srcUrl} from "../../utils/Image";
 
 export default class CroppedImageDialog extends React.PureComponent {
 
@@ -91,6 +92,7 @@ export default class CroppedImageDialog extends React.PureComponent {
             this.setState({busy: true});
             const canvas = document.createElement("canvas");
             const image = this.imageRef;
+            image.setAttribute('crossOrigin', 'anonymous');
             const scaleX = image.naturalWidth / image.width;
             const scaleY = image.naturalHeight / image.height;
             canvas.width = crop.width;
@@ -140,8 +142,9 @@ export default class CroppedImageDialog extends React.PureComponent {
         } else {
             this.setState({busy: true});
             const image = new Image();
+            image.setAttribute('crossOrigin', 'anonymous');
             const type = isSvg ? "svg+xml" : "jpeg";
-            image.src = `data:image/${type};base64,${src}`;
+            image.src = srcUrl(src, type);
             image.onload = () => {
                 const canvas = document.createElement("canvas");
                 canvas.width = 480;
@@ -187,7 +190,7 @@ export default class CroppedImageDialog extends React.PureComponent {
 
     renderImages = (error, src, isSvg, crop, onCancel, onSave, name) => {
         const type = isSvg ? "svg+xml" : "jpeg";
-        const img = `data:image/${type};base64,${src}`;
+        const img = srcUrl(src, type) ;
         return (
             <div className="cropped-image-dialog-container">
                 {(!src) && <div className="no-image">

--- a/client/src/components/redesign/CroppedImageField.jsx
+++ b/client/src/components/redesign/CroppedImageField.jsx
@@ -32,7 +32,7 @@ export default class CroppedImageField extends React.PureComponent {
 
     render() {
         const {dialogOpen, confirmationDialogOpen, confirmationDialogAction} = this.state;
-        const {title, name, value, secondRow = false, initial = false, disabled = false} = this.props;
+        const {title, name, value, isNew, secondRow = false, initial = false, disabled = false} = this.props;
         const imageRequired = !initial && isEmpty(value);
         return (
             <div className={`cropped-image-field ${secondRow ? "second-row" : ""}`}>
@@ -41,8 +41,13 @@ export default class CroppedImageField extends React.PureComponent {
                                     confirm={confirmationDialogAction}
                                     isWarning={true}
                                     question={I18n.t("forms.imageDeleteConfirmation")}/>
-                <CroppedImageDialog onSave={this.onInternalChange} onCancel={this.closeDialog} isOpen={dialogOpen}
-                                    name={name} value={value} title={title}/>
+                <CroppedImageDialog onSave={this.onInternalChange}
+                                    onCancel={this.closeDialog}
+                                    isOpen={dialogOpen}
+                                    isNew={isNew}
+                                    name={name}
+                                    value={value}
+                                    title={title}/>
                 <label className="info" htmlFor="">{title}</label>
                 <section className="file-upload">
                     {!value && <div className={`no-image ${imageRequired ? "error" : ""}`}>

--- a/client/src/components/redesign/Logo.jsx
+++ b/client/src/components/redesign/Logo.jsx
@@ -1,7 +1,15 @@
 import React from "react";
 
 import {ReactComponent as NotFoundIcon} from "../../icons/image-not-found.svg";
+import {isEmpty} from "../../utils/Utils";
+import {srcUrl} from "../../utils/Image";
 
 export default function Logo({src, className = "", alt = ""}) {
-    return src ? <img src={`data:image/jpeg;base64,${src}`} alt={alt} className={className}/> : <NotFoundIcon/>;
+    if (isEmpty(src)) {
+        return <NotFoundIcon/>;
+    }
+    const urlSrc = srcUrl(src, "jpeg");
+    return <img src={urlSrc} alt={alt} className={className}/>
+
+
 }

--- a/client/src/utils/Image.js
+++ b/client/src/utils/Image.js
@@ -1,0 +1,9 @@
+import {isEmpty} from "./Utils";
+
+export function srcUrl(src, type) {
+    if (isEmpty(src)) {
+        return src;
+    }
+    return src.startsWith("http") ? src : `data:image/${type};base64,${src}`
+
+}

--- a/server/__main__.py
+++ b/server/__main__.py
@@ -24,6 +24,7 @@ from server.api.collaborations_services import collaborations_services_api
 from server.api.dynamic_extended_json_encoder import DynamicExtendedJSONEncoder
 from server.api.group import group_api
 from server.api.group_members import group_members_api
+from server.api.image import image_api
 from server.api.invitation import invitations_api
 from server.api.ipaddress import ipaddress_api
 from server.api.join_request import join_request_api
@@ -40,6 +41,7 @@ from server.api.user import user_api
 from server.api.user_saml import user_saml_api
 from server.cron.schedule import start_scheduling
 from server.db.db import db, db_migrations
+from server.db.redis import init_redis
 from server.mqtt.mqtt import MqttClient
 from server.templates import invitation_role
 from server.tools import read_file
@@ -117,6 +119,7 @@ app.register_blueprint(system_api)
 app.register_blueprint(organisations_services_api)
 app.register_blueprint(mock_user_api)
 app.register_blueprint(plsc_api)
+app.register_blueprint(image_api)
 
 app.register_error_handler(404, page_not_found)
 
@@ -141,6 +144,8 @@ app.json_encoder = DynamicExtendedJSONEncoder
 
 db.init_app(app)
 app.db = db
+
+app.redis_client = init_redis(config)
 
 app.app_config = config
 app.app_config["profile"] = profile

--- a/server/api/base.py
+++ b/server/api/base.py
@@ -20,7 +20,7 @@ from server.mail import mail_error
 base_api = Blueprint("base_api", __name__, url_prefix="/")
 
 white_listing = ["health", "config", "info", "api/users/authorization", "api/aup", "api/users/resume-session",
-                 "api/users/me",
+                 "api/users/me", "/api/images/"
                  "api/service_connection_requests/find_by_hash", "api/service_connection_requests/approve",
                  "/api/organisation_invitations/find_by_hash", "/api/invitations/find_by_hash",
                  "api/service_connection_requests/deny", "/api/mock", "/api/users/error"]

--- a/server/api/image.py
+++ b/server/api/image.py
@@ -19,7 +19,7 @@ def get_logo(object_type, sid):
     if object_type not in login_mixins_classes:
         raise BadRequest(f"Not allowed object type {object_type}")
     logo = logo_from_cache(object_type, sid)
-    decoded_logo = base64.decodebytes(logo.encode())
+    decoded_logo = base64.decodebytes(logo)
     res = send_file(io.BytesIO(decoded_logo), mimetype='image/jpeg')
     res.headers.add('Access-Control-Allow-Origin', '*')
     return res

--- a/server/api/image.py
+++ b/server/api/image.py
@@ -1,0 +1,25 @@
+# -*- coding: future_fstrings -*-
+import base64
+import io
+
+from flask import Blueprint, send_file
+from werkzeug.exceptions import BadRequest
+
+from server.db.domain import Service, CollaborationRequest, Organisation, Collaboration
+from server.db.logo_mixin import logo_from_cache
+
+image_api = Blueprint("image_api", __name__, url_prefix="/api/images")
+
+login_mixins_classes = [Collaboration.__tablename__, CollaborationRequest.__tablename__, Organisation.__tablename__,
+                        Service.__tablename__]
+
+
+@image_api.route("/<object_type>/<sid>", strict_slashes=False)
+def get_logo(object_type, sid):
+    if object_type not in login_mixins_classes:
+        raise BadRequest(f"Not allowed object type {object_type}")
+    logo = logo_from_cache(object_type, sid)
+    decoded_logo = base64.decodebytes(logo.encode())
+    res = send_file(io.BytesIO(decoded_logo), mimetype='image/jpeg')
+    res.headers.add('Access-Control-Allow-Origin', '*')
+    return res

--- a/server/config/test_config.yml
+++ b/server/config/test_config.yml
@@ -3,6 +3,11 @@ database:
 
 secret_key: secret
 
+redis:
+  host: localhost
+  port: 6379
+  password:
+
 api_users:
   - name: "sysadmin"
     password: "secret"
@@ -66,6 +71,7 @@ aup:
   html: SURFresearch-Access-Management-AUP-01122019-0001.html
 
 base_url: http://localhost:3000/
+base_server_url: http://localhost:8080
 wiki_link: https://wiki.surfnet.nl/display/sram
 
 admin_users:

--- a/server/db/domain.py
+++ b/server/db/domain.py
@@ -4,6 +4,7 @@ from sqlalchemy.orm import column_property
 
 from server.db.audit_mixin import Base, metadata
 from server.db.db import db
+from server.db.logo_mixin import LogoMixin
 
 
 class User(Base, db.Model):
@@ -135,7 +136,7 @@ services_collaborations_association = db.Table(
 )
 
 
-class Collaboration(Base, db.Model):
+class Collaboration(Base, db.Model, LogoMixin):
     __tablename__ = "collaborations"
     id = db.Column("id", db.Integer(), primary_key=True, nullable=False, autoincrement=True)
     identifier = db.Column("identifier", db.String(length=255), nullable=False)
@@ -200,7 +201,7 @@ class OrganisationMembership(Base, db.Model):
                            nullable=False)
 
 
-class Organisation(Base, db.Model):
+class Organisation(Base, db.Model, LogoMixin):
     __tablename__ = "organisations"
     id = db.Column("id", db.Integer(), primary_key=True, nullable=False, autoincrement=True)
     name = db.Column("name", db.String(length=255), nullable=False)
@@ -247,7 +248,7 @@ class Organisation(Base, db.Model):
         return len(list(filter(lambda membership: membership.user_id == user_id, self.organisation_memberships))) > 0
 
 
-class Service(Base, db.Model):
+class Service(Base, db.Model, LogoMixin):
     __tablename__ = "services"
     id = db.Column("id", db.Integer(), primary_key=True, nullable=False, autoincrement=True)
     entity_id = db.Column("entity_id", db.String(length=255), nullable=False)
@@ -378,7 +379,7 @@ class SuspendNotification(Base, db.Model):
     is_primary = db.Column("is_primary", db.Boolean(), nullable=True, default=False)
 
 
-class CollaborationRequest(Base, db.Model):
+class CollaborationRequest(Base, db.Model, LogoMixin):
     __tablename__ = "collaboration_requests"
     id = db.Column("id", db.Integer(), primary_key=True, nullable=False, autoincrement=True)
     name = db.Column("name", db.String(length=255), nullable=False)

--- a/server/db/logo_mixin.py
+++ b/server/db/logo_mixin.py
@@ -1,0 +1,44 @@
+from flask import current_app
+from sqlalchemy import text, bindparam, Integer
+
+
+def _redis_key(object_type, sid):
+    return f"{object_type}_{sid}"
+
+
+def logo_from_cache(object_type, sid):
+    value = current_app.redis_client.get(_redis_key(object_type, sid))
+    if not value:
+        # This will not happen often, but if external parties use the image url it is theoretically possible
+        sql = text(f"SELECT logo FROM {object_type} where id = :sid")
+        sql = sql.bindparams(bindparam("sid", type_=Integer))
+
+        from server.db.db import db
+
+        result_set = db.engine.execute(sql, sid=(int(sid)))
+        value = next(result_set)[0]
+        current_app.redis_client.set(_redis_key(object_type, sid), value)
+        return value
+    return value.decode()
+
+
+def evict_from_cache(object_type, sid):
+    current_app.redis_client.delete(_redis_key(object_type, sid))
+
+
+class LogoMixin(object):
+
+    def __getattribute__(self, name):
+        if name == "logo":
+            logo = object.__getattribute__(self, name)
+            if not logo:
+                return logo
+
+            object_type = str(self._sa_class_manager.mapper.persist_selectable.name)
+            sid = str(self.id)
+            redis_key = _redis_key(object_type, sid)
+            if not current_app.redis_client.exists(redis_key):
+                current_app.redis_client.set(redis_key, logo)
+            return f"{current_app.app_config.base_server_url}/api/images/{object_type}/{sid}"
+
+        return object.__getattribute__(self, name)

--- a/server/db/logo_mixin.py
+++ b/server/db/logo_mixin.py
@@ -18,8 +18,8 @@ def logo_from_cache(object_type, sid):
         result_set = db.engine.execute(sql, sid=(int(sid)))
         value = next(result_set)[0]
         current_app.redis_client.set(_redis_key(object_type, sid), value)
-        return value
-    return value.decode()
+        return value.encode()
+    return value
 
 
 def evict_from_cache(object_type, sid):

--- a/server/db/models.py
+++ b/server/db/models.py
@@ -8,6 +8,7 @@ from server.auth.security import current_user_uid
 from server.db.db import db
 from server.db.domain import User, CollaborationMembership, OrganisationMembership, JoinRequest, Collaboration, \
     Invitation, Service, Aup, IpNetwork, Group, SchacHomeOrganisation
+from server.db.logo_mixin import evict_from_cache
 
 deserialization_mapping = {"users": User, "collaboration_memberships": CollaborationMembership,
                            "join_requests": JoinRequest, "collaborations": Collaboration,
@@ -38,6 +39,9 @@ def _merge(cls, d):
     o = cls(**d)
     merged = db.session.merge(o)
     db.session.commit()
+    if hasattr(merged, "logo"):
+        object_type = str(cls._sa_class_manager.mapper.persist_selectable.name)
+        evict_from_cache(object_type, getattr(merged, "id"))
     return merged
 
 

--- a/server/db/redis.py
+++ b/server/db/redis.py
@@ -1,0 +1,8 @@
+import redis
+
+
+def init_redis(app_conf):
+    password = app_conf.redis.password
+    return redis.Redis(host=app_conf.redis.host,
+                       port=app_conf.redis.port,
+                       password=password if password else None)

--- a/server/requirements/base.txt
+++ b/server/requirements/base.txt
@@ -20,3 +20,4 @@ requests==2.24.0
 uWSGI==2.0.19.1
 urllib3==1.25.10
 websockets==9.0.1
+redis==3.5.3

--- a/server/test/api/test_image.py
+++ b/server/test/api/test_image.py
@@ -1,0 +1,36 @@
+# -*- coding: future_fstrings -*-
+import re
+
+from server.db.domain import Service, CollaborationRequest
+from server.test.abstract_test import AbstractTest
+from server.test.seed import uuc_scheduler_name, collaboration_request_name
+
+
+class TestImage(AbstractTest):
+
+    def test_find_image(self):
+        service = self.find_entity_by_name(Service, uuc_scheduler_name)
+        res = self.client.get(f"/api/images/services/{service.id}")
+
+        self.assertEqual("*", res.headers["Access-Control-Allow-Origin"])
+        self.assertIsNotNone(res.data)
+
+    def test_logo_url(self):
+        collaborations = self.get("/api/collaborations/all")
+        self.assertEqual(4, len(collaborations))
+        pattern = re.compile("^http://localhost:8080/api/images/collaborations/([0-9]+)$")
+        for coll in collaborations:
+            self.assertTrue(pattern.match(coll["logo"]))
+
+    def test_find_image_sql_injection(self):
+        res = self.client.get("/api/images/evil/5")
+        self.assertEqual(400, res.status_code)
+
+    def test_collaboration_request(self):
+        collaboration_request_id = self.find_entity_by_name(CollaborationRequest, collaboration_request_name).id
+        self.login("urn:john")
+        collaboration_request = self.get(f"/api/collaboration_requests/{collaboration_request_id}")
+        self.assertEqual(collaboration_request["logo"],
+                         f"http://localhost:8080/api/images/collaboration_requests/{collaboration_request_id}")
+        res = self.client.get(f"/api/images/collaboration_requests/{collaboration_request_id}")
+        self.assertIsNotNone(res.data)

--- a/server/test/api/test_service.py
+++ b/server/test/api/test_service.py
@@ -33,10 +33,16 @@ class TestService(AbstractTest):
 
     def test_find_by_id_admin(self):
         service = self.find_entity_by_name(Service, uuc_scheduler_name)
+        logo = self.client.get(f"/api/images/services/{service.id}").data
+        self.assertIsNotNone(logo)
+
         self.login("urn:john")
         service = self.get(f"api/services/{service.id}", with_basic_auth=False)
         self.assertEqual(1, len(service["organisations"]))
         self.assertEqual(2, len(service["service_organisation_collaborations"]))
+
+        logo_data = self.client.get(service["logo"]).data
+        self.assertEqual(logo, logo_data)
 
     def test_find_by_id_api_call(self):
         service = self.find_entity_by_name(Service, uuc_scheduler_name)


### PR DESCRIPTION
Currently the API serves the base64 encoded images for entities which
have a logo. Now we serve URL's that the clients can use to download
the image. We cache the images using redis and invalidate / refresh
logo's after updates.

Note that this branch can only be merged to main if Redis is available on the AWS infrastructure.