### PR TITLE
Updated translation: org admin count

### DIFF
--- a/client/src/locale/en.js
+++ b/client/src/locale/en.js
@@ -232,7 +232,7 @@ I18n.translations.en = {
             searchPlaceHolder: "Search organisations...",
             new: "New organisation",
             name: "Name",
-            memberCount: "Members",
+            memberCount: "Admins",
             collaborationCount: "Collaborations",
             schacHomeOrganisations: "Org domain(s)",
             category: "Category",

--- a/client/src/locale/nl.js
+++ b/client/src/locale/nl.js
@@ -232,7 +232,7 @@ I18n.translations.nl = {
             searchPlaceHolder: "Zoek organisaties...",
             new: "Nieuwe organisatie",
             name: "Naam",
-            memberCount: "Leden",
+            memberCount: "Beheerders",
             collaborationCount: "Samenwerkingen",
             schacHomeOrganisations: "Organisatiedomein(en)",
             category: "Categorie",


### PR DESCRIPTION
In the organisations table, the 'members' column displays the number of organisation admins and organisation managers.
This commit intends to change the header text, and only that header text.