### PR TITLE
Add /api/plsc/ip_ranges endpoint with new scope

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,6 +60,7 @@ jobs:
           "
       - name: Install SAML2 dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y libxml2-dev libxmlsec1-dev
       # Run Checkout code
       - name: Checkout

--- a/client/package.json
+++ b/client/package.json
@@ -50,7 +50,7 @@
         "test": "react-scripts test",
         "analyze": "source-map-explorer build/static/js/main.*"
     },
-    "proxy": "http://localhost:8080",
+    "proxy": "http://127.0.0.1:8080/",
     "eslintConfig": {
         "extends": "react-app"
     },

--- a/server/api/collaboration.py
+++ b/server/api/collaboration.py
@@ -257,7 +257,7 @@ def collaboration_access_allowed(collaboration_id):
 @collaboration_api.route("/<collaboration_id>", strict_slashes=False)
 @json_endpoint
 def collaboration_by_id(collaboration_id):
-    confirm_collaboration_admin(collaboration_id)
+    confirm_collaboration_admin(collaboration_id, read_only=True)
 
     collaboration = Collaboration.query \
         .options(selectinload(Collaboration.organisation).selectinload(Organisation.services)) \

--- a/server/api/organisation.py
+++ b/server/api/organisation.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import selectinload
 
 from server.api.base import json_endpoint, query_param, replace_full_text_search_boolean_mode_chars
 from server.auth.security import confirm_write_access, current_user_id, is_application_admin, \
-    confirm_organisation_admin, generate_token, is_service_admin, confirm_external_api_call
+    confirm_organisation_admin, generate_token, is_service_admin, confirm_external_api_call, confirm_read_access
 from server.cron.idp_metadata_parser import idp_display_name
 from server.db.db import db
 from server.db.defaults import default_expiry_date, cleanse_short_name
@@ -66,7 +66,7 @@ def schac_home_exists():
 @organisation_api.route("/all", strict_slashes=False)
 @json_endpoint
 def organisation_all():
-    confirm_write_access()
+    confirm_read_access()
     organisations = Organisation.query.all()
     return organisations, 200
 

--- a/server/api/plsc.py
+++ b/server/api/plsc.py
@@ -5,6 +5,7 @@ from flask import Blueprint
 from server.api.base import json_endpoint
 from server.auth.security import confirm_read_access
 from server.db.db import db
+from server.db.domain import IpNetwork
 from server.db.logo_mixin import logo_url
 
 plsc_api = Blueprint("plsc_api", __name__, url_prefix="/api/plsc")
@@ -130,3 +131,12 @@ def sync():
         result["users"].append(user_row)
 
     return result, 200
+
+
+@plsc_api.route("/ip_ranges", strict_slashes=False)
+@json_endpoint
+def ip_ranges():
+    confirm_read_access()
+    data = IpNetwork.query.all()
+    ip_networks = set(r.network_value for r in data)
+    return {"service_ipranges": list(ip_networks)}, 200

--- a/server/api/plsc.py
+++ b/server/api/plsc.py
@@ -3,7 +3,7 @@
 from flask import Blueprint
 
 from server.api.base import json_endpoint
-from server.auth.security import confirm_read_access
+from server.auth.security import confirm_read_access, confirm_ipaddress_access
 from server.db.db import db
 from server.db.domain import IpNetwork
 from server.db.logo_mixin import logo_url
@@ -136,7 +136,7 @@ def sync():
 @plsc_api.route("/ip_ranges", strict_slashes=False)
 @json_endpoint
 def ip_ranges():
-    confirm_read_access()
+    confirm_ipaddress_access()
     data = IpNetwork.query.all()
     ip_networks = set(r.network_value for r in data)
     return {"service_ipranges": list(ip_networks)}, 200

--- a/server/auth/security.py
+++ b/server/auth/security.py
@@ -161,7 +161,7 @@ def confirm_organisation_admin_or_manager(organisation_id):
     confirm_write_access(override_func=override_func)
 
 
-def confirm_collaboration_admin(collaboration_id, org_manager_allowed=True):
+def confirm_collaboration_admin(collaboration_id, org_manager_allowed=True, read_only=False):
     def override_func():
         user_id = current_user_id()
         coll_admin = is_collaboration_admin(user_id, collaboration_id)
@@ -174,7 +174,10 @@ def confirm_collaboration_admin(collaboration_id, org_manager_allowed=True):
             return allowed
         return True
 
-    confirm_write_access(override_func=override_func)
+    if read_only:
+        confirm_read_access(override_func=override_func)
+    else:
+        confirm_write_access(override_func=override_func)
 
 
 def confirm_collaboration_member(collaboration_id):

--- a/server/auth/security.py
+++ b/server/auth/security.py
@@ -87,18 +87,25 @@ def confirm_authorized_api_call():
         raise Forbidden()
 
 
-def confirm_read_access(*args, override_func=None):
+def confirm_scope_access(*args, override_func=None, scope):
     if request_context.is_authorized_api_call:
-        return "read" in request_context.api_user.scopes
-    if not is_application_admin() and (not override_func or not override_func(*args)):
+        if scope is None or scope not in request_context.api_user.scopes:
+            raise Forbidden()
+    elif not is_application_admin() and (not override_func or not override_func(*args)):
         raise Forbidden()
+    return True
+
+
+def confirm_read_access(*args, override_func=None):
+    return confirm_scope_access(*args, override_func=override_func, scope="read")
 
 
 def confirm_write_access(*args, override_func=None):
-    if request_context.is_authorized_api_call:
-        return "system" in request_context.api_user.scopes
-    if not is_application_admin() and (not override_func or not override_func(*args)):
-        raise Forbidden()
+    return confirm_scope_access(*args, override_func=override_func, scope="write")
+
+
+def confirm_ipaddress_access(*args, override_func=None):
+    return confirm_scope_access(*args, override_func=override_func, scope="ipaddress")
 
 
 def is_current_user_collaboration_admin(collaboration_id):

--- a/server/config/test_config.yml
+++ b/server/config/test_config.yml
@@ -14,13 +14,16 @@ redis:
 api_users:
   - name: "sysadmin"
     password: "secret"
-    scopes: [ read, write, system ]
+    scopes: [ "read", "write", "system", "ipaddress" ]
   - name: "sysread"
     password: "secret"
     scopes: [ read ]
   - name: "research_cloud"
     password: "secret"
     scopes: [ "restricted_co" ]
+  - name: "ipaddress"
+    password: "secret"
+    scopes: [ "ipaddress" ]
 
 oidc:
   client_id: sram

--- a/server/db/domain.py
+++ b/server/db/domain.py
@@ -553,6 +553,7 @@ class IpNetwork(Base, db.Model):
     id = db.Column("id", db.Integer(), primary_key=True, nullable=False, autoincrement=True)
     network_value = db.Column("network_value", db.Text(), nullable=False)
     service_id = db.Column(db.Integer(), db.ForeignKey("services.id"))
+    service = db.relationship("Service", back_populates="ip_networks")
     created_by = db.Column("created_by", db.String(length=512), nullable=False)
     created_at = db.Column("created_at", db.DateTime(timezone=True), server_default=db.text("CURRENT_TIMESTAMP"),
                            nullable=False)

--- a/server/test/api/test_plsc.py
+++ b/server/test/api/test_plsc.py
@@ -7,7 +7,7 @@ from server.test.seed import sarah_name, service_wiki_entity_id, uuc_name, ai_co
 
 class TestPlsc(AbstractTest):
 
-    def test_fetch(self):
+    def test_sync_fetch(self):
         res = self.get("/api/plsc/sync")
         self.assertEqual(3, len(res["organisations"]))
         logo = res["organisations"][0]["logo"]
@@ -68,3 +68,11 @@ class TestPlsc(AbstractTest):
 
         group_membership = ai_researchers["collaboration_memberships"][0]
         self.assertIsNotNone(group_membership["user_id"])
+
+    def test_ipranges_fetch(self):
+        res = self.get("/api/plsc/ip_ranges")
+        self.assertTrue("service_ipranges" in res)
+        self.assertEqual(3, len(res["service_ipranges"]))
+        self.assertTrue("192.0.2.0/24" in res["service_ipranges"])
+        self.assertTrue("2001:db8:0:0::/64" in res["service_ipranges"])
+        self.assertTrue("2001:db8:1:0::/64" in res["service_ipranges"])

--- a/server/test/api/test_plsc.py
+++ b/server/test/api/test_plsc.py
@@ -84,9 +84,9 @@ class TestPlsc(AbstractTest):
         self.assertTrue("2001:db8:1:0::/64" in res["service_ipranges"])
 
     def test_ipranges_api_auth(self):
-        res = self.get(f"/api/plsc/ip_ranges", headers=AUTH_HEADER_READ, with_basic_auth=False,
+        res = self.get("/api/plsc/ip_ranges", headers=AUTH_HEADER_READ, with_basic_auth=False,
                        response_status_code=403)
         self.assertTrue(res['error'] is True)
 
-        res = self.get(f"/api/plsc/ip_ranges", headers=AUTH_HEADER_IPADDRESS, with_basic_auth=False)
+        res = self.get("/api/plsc/ip_ranges", headers=AUTH_HEADER_IPADDRESS, with_basic_auth=False)
         self.assertEqual(3, len(res["service_ipranges"]))

--- a/server/test/api/test_plsc.py
+++ b/server/test/api/test_plsc.py
@@ -1,8 +1,14 @@
 # -*- coding: future_fstrings -*-
+from base64 import b64encode
+
 from server.db.models import flatten
 from server.test.abstract_test import AbstractTest
 from server.test.seed import sarah_name, service_wiki_entity_id, uuc_name, ai_computing_name, ai_researchers_group, \
     the_boss_name, service_storage_entity_id
+
+
+AUTH_HEADER_READ = {"Authorization": f"Basic {b64encode(b'sysread:secret').decode('ascii')}"}
+AUTH_HEADER_IPADDRESS = {"Authorization": f"Basic {b64encode(b'ipaddress:secret').decode('ascii')}"}
 
 
 class TestPlsc(AbstractTest):
@@ -76,3 +82,11 @@ class TestPlsc(AbstractTest):
         self.assertTrue("192.0.2.0/24" in res["service_ipranges"])
         self.assertTrue("2001:db8:0:0::/64" in res["service_ipranges"])
         self.assertTrue("2001:db8:1:0::/64" in res["service_ipranges"])
+
+    def test_ipranges_api_auth(self):
+        res = self.get(f"/api/plsc/ip_ranges", headers=AUTH_HEADER_READ, with_basic_auth=False,
+                       response_status_code=403)
+        self.assertTrue(res['error'] is True)
+
+        res = self.get(f"/api/plsc/ip_ranges", headers=AUTH_HEADER_IPADDRESS, with_basic_auth=False)
+        self.assertEqual(3, len(res["service_ipranges"]))

--- a/server/test/seed.py
+++ b/server/test/seed.py
@@ -13,7 +13,7 @@ from server.db.defaults import default_expiry_date
 from server.db.domain import User, Organisation, OrganisationMembership, Service, Collaboration, \
     CollaborationMembership, JoinRequest, Invitation, Group, OrganisationInvitation, ApiKey, CollaborationRequest, \
     ServiceConnectionRequest, SuspendNotification, Aup, SchacHomeOrganisation, SshKey, ServiceGroup, ServiceInvitation, \
-    ServiceMembership, ServiceAup, UserToken, UserIpNetwork, Tag, PamSSOSession
+    ServiceMembership, ServiceAup, UserToken, UserIpNetwork, Tag, PamSSOSession, IpNetwork
 
 collaboration_request_name = "New Collaboration"
 
@@ -352,6 +352,12 @@ def seed(db, app_config, skip_seed=False, perf_test=False):
                                       description="Wiki group",
                                       service=wiki)
     _persist(db, service_group_mail, service_group_wiki)
+
+    service_iprange_cloud_v4 = IpNetwork(network_value="192.0.2.0/24", service=cloud)
+    service_iprange_cloud_v6 = IpNetwork(network_value="2001:db8:0:0::/64", service=cloud)
+    service_iprange_wiki_v4 = IpNetwork(network_value="192.0.2.0/24", service=wiki)
+    service_iprange_wiki_v6 = IpNetwork(network_value="2001:db8:1:0::/64", service=wiki)
+    _persist(db, service_iprange_cloud_v4, service_iprange_cloud_v6, service_iprange_wiki_v4, service_iprange_wiki_v6)
 
     uuc.services.append(uuc_scheduler)
     uuc.services.append(wiki)


### PR DESCRIPTION
I need this endpoint to be able to feed the ip addresses defined by Services to haproxy acls, and I don't want the loadbalancers to have full access to all SBS data.