### PR TITLE
removed erroneous space in json key

### DIFF
--- a/server/api/token.py
+++ b/server/api/token.py
@@ -68,7 +68,7 @@ def introspect():
             "voperson_external_affiliation": user.scoped_affiliation,
             "uid": user.uid,
             "username": user.username,
-            "eduperson_entitlement ": list(entitlements)
+            "eduperson_entitlement": list(entitlements)
         }
     }
     return result, 200


### PR DESCRIPTION
The https://sram.surf.nl/api/tokens/introspect output has a space in the key "user.eduperson_entitlement ". that is wrong.