### PR TITLE
Fix mfa flows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -217,7 +217,7 @@ jobs:
         if: "github.ref_type=='tag'"
         uses: softprops/action-gh-release@v1
         with:
-          files: "${{steps.fetch_artifact.outputs.download-path}}"
+          files: "${{steps.fetch_artifact.outputs.download-path}}/*"
 
       - name: Advance latest tag
         if: "github.ref_name=='main'"
@@ -227,6 +227,7 @@ jobs:
           description: "Latest commit in the main branch"
 
       - name: remove all previous "latest" releases
+        if: "github.ref_name=='main'"
         uses: dev-drprasad/delete-older-releases@v0.2.0
         with:
           keep_latest: 0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,89 +15,89 @@ on:
   workflow_dispatch:
 
 jobs:
-#  Server_tests:
-#    name: Server tests
-#    if: always()
-#
-#    runs-on: ubuntu-latest
-#
-#    # Test different python versions
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        python-version: ['3.7', '3.9', '3.10']
-#
-#    services:
-#      # How to use MySQL
-#      mysql:
-#        image: mysql:5.7
-#        env:
-#          MYSQL_ROOT_PASSWORD: root
-#        ports:
-#          - 3306:3306
-#        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
-#      redis:
-#        # Docker Hub image
-#        image: redis
-#        # Set health checks to wait until redis has started
-#        options: >-
-#          --health-cmd "redis-cli ping"
-#          --health-interval 10s
-#          --health-timeout 5s
-#          --health-retries 5
-#        ports:
-#          # Maps port 6379 on service container to the host
-#          - 6379:6379
-#
-#    steps:
-#      - name: Setup mysql server
-#        run: >
-#          mysql -uroot -proot -h127.0.0.1 -e "
-#            DROP DATABASE IF EXISTS sbs_test;
-#            CREATE DATABASE IF NOT EXISTS sbs_test DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;
-#            CREATE USER 'sbs'@'%' IDENTIFIED BY 'sbs';
-#            GRANT ALL PRIVILEGES ON *.* TO 'sbs'@'%' WITH GRANT OPTION;
-#          "
-#      - name: Install SAML2 dependencies
-#        run: |
-#          sudo apt-get update
-#          sudo apt-get install -y libxml2-dev libxmlsec1-dev
-#      # Run Checkout code
-#      - name: Checkout
-#        uses: actions/checkout@v3
-#
-#      - name: Set up Python ${{ matrix.python-version }}
-#        uses: actions/setup-python@v3
-#        with:
-#          python-version: ${{ matrix.python-version }}
-#          cache: 'pip'
-#          cache-dependency-path: 'server/requirements/*.txt'
-#
-#      - name: Display Python version
-#        run: python -c "import sys; print(sys.version)"
-#
-#      - name: Install dependencies
-#        run: |
-#          python -m pip install pip setuptools wheel
-#          pip install -r ./server/requirements/test.txt
-#          pip install codecov flake8
-#
-#      # Setup tmate session
-#      #- name: Setup tmate session
-#      #  uses: mxschmitt/action-tmate@v3
-#
-#      - name: Run flake8
-#        run: |
-#          flake8 ./server/
-#
-#      - name: Run tests
-#        run: |
-#          pytest --cov=server server/test
-#
-#      - name: The job has succeeded
-#        run: codecov --token=${{ secrets.CODECOV_TOKEN }}
-#        if: ${{ success() }}
-#
+  Server_tests:
+    name: Server tests
+    if: always()
+
+    runs-on: ubuntu-latest
+
+    # Test different python versions
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.7', '3.9', '3.10']
+
+    services:
+      # How to use MySQL
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+      redis:
+        # Docker Hub image
+        image: redis
+        # Set health checks to wait until redis has started
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          # Maps port 6379 on service container to the host
+          - 6379:6379
+
+    steps:
+      - name: Setup mysql server
+        run: >
+          mysql -uroot -proot -h127.0.0.1 -e "
+            DROP DATABASE IF EXISTS sbs_test;
+            CREATE DATABASE IF NOT EXISTS sbs_test DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;
+            CREATE USER 'sbs'@'%' IDENTIFIED BY 'sbs';
+            GRANT ALL PRIVILEGES ON *.* TO 'sbs'@'%' WITH GRANT OPTION;
+          "
+      - name: Install SAML2 dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libxml2-dev libxmlsec1-dev
+      # Run Checkout code
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: 'server/requirements/*.txt'
+
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install pip setuptools wheel
+          pip install -r ./server/requirements/test.txt
+          pip install codecov flake8
+
+      # Setup tmate session
+      #- name: Setup tmate session
+      #  uses: mxschmitt/action-tmate@v3
+
+      - name: Run flake8
+        run: |
+          flake8 ./server/
+
+      - name: Run tests
+        run: |
+          pytest --cov=server server/test
+
+      - name: The job has succeeded
+        run: codecov --token=${{ secrets.CODECOV_TOKEN }}
+        if: ${{ success() }}
+
 
   Client_build:
     name: Client build
@@ -191,7 +191,7 @@ jobs:
       ( github.ref_type=='tag' || github.ref_name=='main' )
     needs:
       - "Client_build"
-#      - "Server_tests"
+      - "Server_tests"
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,89 +15,89 @@ on:
   workflow_dispatch:
 
 jobs:
-  Server_tests:
-    name: Server tests
-    if: always()
-
-    runs-on: ubuntu-latest
-
-    # Test different python versions
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ['3.7', '3.9', '3.10']
-
-    services:
-      # How to use MySQL
-      mysql:
-        image: mysql:5.7
-        env:
-          MYSQL_ROOT_PASSWORD: root
-        ports:
-          - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
-      redis:
-        # Docker Hub image
-        image: redis
-        # Set health checks to wait until redis has started
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          # Maps port 6379 on service container to the host
-          - 6379:6379
-
-    steps:
-      - name: Setup mysql server
-        run: >
-          mysql -uroot -proot -h127.0.0.1 -e "
-            DROP DATABASE IF EXISTS sbs_test;
-            CREATE DATABASE IF NOT EXISTS sbs_test DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;
-            CREATE USER 'sbs'@'%' IDENTIFIED BY 'sbs';
-            GRANT ALL PRIVILEGES ON *.* TO 'sbs'@'%' WITH GRANT OPTION;
-          "
-      - name: Install SAML2 dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libxml2-dev libxmlsec1-dev
-      # Run Checkout code
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-          cache-dependency-path: 'server/requirements/*.txt'
-
-      - name: Display Python version
-        run: python -c "import sys; print(sys.version)"
-
-      - name: Install dependencies
-        run: |
-          python -m pip install pip setuptools wheel
-          pip install -r ./server/requirements/test.txt
-          pip install codecov flake8
-
-      # Setup tmate session
-      #- name: Setup tmate session
-      #  uses: mxschmitt/action-tmate@v3
-
-      - name: Run flake8
-        run: |
-          flake8 ./server/
-
-      - name: Run tests
-        run: |
-          pytest --cov=server server/test
-
-      - name: The job has succeeded
-        run: codecov --token=${{ secrets.CODECOV_TOKEN }}
-        if: ${{ success() }}
-
+#  Server_tests:
+#    name: Server tests
+#    if: always()
+#
+#    runs-on: ubuntu-latest
+#
+#    # Test different python versions
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        python-version: ['3.7', '3.9', '3.10']
+#
+#    services:
+#      # How to use MySQL
+#      mysql:
+#        image: mysql:5.7
+#        env:
+#          MYSQL_ROOT_PASSWORD: root
+#        ports:
+#          - 3306:3306
+#        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+#      redis:
+#        # Docker Hub image
+#        image: redis
+#        # Set health checks to wait until redis has started
+#        options: >-
+#          --health-cmd "redis-cli ping"
+#          --health-interval 10s
+#          --health-timeout 5s
+#          --health-retries 5
+#        ports:
+#          # Maps port 6379 on service container to the host
+#          - 6379:6379
+#
+#    steps:
+#      - name: Setup mysql server
+#        run: >
+#          mysql -uroot -proot -h127.0.0.1 -e "
+#            DROP DATABASE IF EXISTS sbs_test;
+#            CREATE DATABASE IF NOT EXISTS sbs_test DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;
+#            CREATE USER 'sbs'@'%' IDENTIFIED BY 'sbs';
+#            GRANT ALL PRIVILEGES ON *.* TO 'sbs'@'%' WITH GRANT OPTION;
+#          "
+#      - name: Install SAML2 dependencies
+#        run: |
+#          sudo apt-get update
+#          sudo apt-get install -y libxml2-dev libxmlsec1-dev
+#      # Run Checkout code
+#      - name: Checkout
+#        uses: actions/checkout@v3
+#
+#      - name: Set up Python ${{ matrix.python-version }}
+#        uses: actions/setup-python@v3
+#        with:
+#          python-version: ${{ matrix.python-version }}
+#          cache: 'pip'
+#          cache-dependency-path: 'server/requirements/*.txt'
+#
+#      - name: Display Python version
+#        run: python -c "import sys; print(sys.version)"
+#
+#      - name: Install dependencies
+#        run: |
+#          python -m pip install pip setuptools wheel
+#          pip install -r ./server/requirements/test.txt
+#          pip install codecov flake8
+#
+#      # Setup tmate session
+#      #- name: Setup tmate session
+#      #  uses: mxschmitt/action-tmate@v3
+#
+#      - name: Run flake8
+#        run: |
+#          flake8 ./server/
+#
+#      - name: Run tests
+#        run: |
+#          pytest --cov=server server/test
+#
+#      - name: The job has succeeded
+#        run: codecov --token=${{ secrets.CODECOV_TOKEN }}
+#        if: ${{ success() }}
+#
 
   Client_build:
     name: Client build
@@ -191,7 +191,7 @@ jobs:
       ( github.ref_type=='tag' || github.ref_name=='main' )
     needs:
       - "Client_build"
-      - "Server_tests"
+#      - "Server_tests"
 
     runs-on: ubuntu-latest
 

--- a/client/src/pages/App.jsx
+++ b/client/src/pages/App.jsx
@@ -233,7 +233,8 @@ class App extends React.Component {
                                    return <Redirect to={decodeURIComponent(state)}/>
                                }}/>
                         <Route path="/2fa/:second_fa_uuid?"
-                               render={props => <SecondFactorAuthentication user={currentUser}
+                               render={props => <SecondFactorAuthentication config={config}
+                                                                            user={currentUser}
                                                                             refreshUser={this.refreshUserMemberships}
                                                                             {...props}/>}/>
                         <Route path="/2fa-update"

--- a/client/src/pages/SecondFactorAuthentication.jsx
+++ b/client/src/pages/SecondFactorAuthentication.jsx
@@ -62,9 +62,7 @@ class SecondFactorAuthentication extends React.Component {
                             qrCode: res.qr_code_base64,
                             idp_name: res.idp_name || I18n.t("mfa.register.unknownIdp"),
                             continueUrl: continueUrl
-                            // hier ssid_needed vars toevoegen in state
                         });
-                        // hier checken of we ssid moeten doen;  zo ja, rediretc url ophalen en op de een of andere manier original_destination in sessie zetten en user redirecten
                         this.focusCode();
                     }).catch(() => this.props.history.push(`/404?eo=${ErrorOrigins.invalidSecondFactorUUID}`))
             } else {

--- a/client/src/pages/SecondFactorAuthentication.jsx
+++ b/client/src/pages/SecondFactorAuthentication.jsx
@@ -47,17 +47,25 @@ class SecondFactorAuthentication extends React.Component {
     }
 
     componentDidMount() {
-        const {user, update, match} = this.props;
         console.log("2fa start");
-        debugger;
+
+        const {config, user, update, match} = this.props;
+
+        const urlSearchParams = new URLSearchParams(window.location.search);
+        const continueUrl = urlSearchParams.get("continue_url");
+        const continueUrlTrusted = config.continue_eduteams_redirect_uri;
+        if (continueUrl && !continueUrl.toLowerCase().startsWith(continueUrlTrusted.toLowerCase())) {
+            throw new Error(`Invalid continue url: '${continueUrl}'`)
+        }
+
         console.log(user);
         console.log(update);
         console.log(match);
+        console.log(config);
+
         if (user.guest) {
             console.log("path 1");
             const second_fa_uuid = match.params.second_fa_uuid;
-            const urlSearchParams = new URLSearchParams(window.location.search);
-            const continueUrl = urlSearchParams.get("continue_url");
             if (second_fa_uuid && continueUrl) {
                 //We need to know if this is a new user. We use the second_fa_uuid for this
                 get2faProxyAuthz(second_fa_uuid)
@@ -76,7 +84,11 @@ class SecondFactorAuthentication extends React.Component {
             }
         } else if (user.second_factor_confirmed && !update) {
             console.log("path 2");
-            this.props.history.push("/home")
+            if (continueUrl) {
+                window.location.href = continueUrl
+            } else {
+                this.props.history.push("/home")
+            }
         } else if (!user.second_factor_auth || update) {
             console.log("path 3");
             get2fa().then(res => {

--- a/client/src/pages/SecondFactorAuthentication.jsx
+++ b/client/src/pages/SecondFactorAuthentication.jsx
@@ -94,7 +94,10 @@ class SecondFactorAuthentication extends React.Component {
             });
         } else {
             console.log("path 4");
-            this.setState({loading: false});
+            this.setState({
+                continueUrl: continueUrl,
+                loading: false
+            });
             this.focusCode();
         }
     }

--- a/client/src/pages/SecondFactorAuthentication.jsx
+++ b/client/src/pages/SecondFactorAuthentication.jsx
@@ -54,6 +54,7 @@ class SecondFactorAuthentication extends React.Component {
         console.log(update);
         console.log(match);
         if (user.guest) {
+            console.log("path 1");
             const second_fa_uuid = match.params.second_fa_uuid;
             const urlSearchParams = new URLSearchParams(window.location.search);
             const continueUrl = urlSearchParams.get("continue_url");
@@ -74,8 +75,10 @@ class SecondFactorAuthentication extends React.Component {
                 this.props.history.push("/landing");
             }
         } else if (user.second_factor_confirmed && !update) {
+            console.log("path 2");
             this.props.history.push("/home")
         } else if (!user.second_factor_auth || update) {
+            console.log("path 3");
             get2fa().then(res => {
                 this.setState({
                     qrCode: res.qr_code_base64,
@@ -85,6 +88,7 @@ class SecondFactorAuthentication extends React.Component {
                 this.focusCode();
             });
         } else {
+            console.log("path 4");
             this.setState({loading: false});
             this.focusCode();
         }

--- a/client/src/pages/SecondFactorAuthentication.jsx
+++ b/client/src/pages/SecondFactorAuthentication.jsx
@@ -52,6 +52,8 @@ class SecondFactorAuthentication extends React.Component {
         const {config, user, update, match} = this.props;
 
         const urlSearchParams = new URLSearchParams(window.location.search);
+        const second_fa_uuid = match.params.second_fa_uuid;
+
         const continueUrl = urlSearchParams.get("continue_url");
         const continueUrlTrusted = config.continue_eduteams_redirect_uri;
         if (continueUrl && !continueUrl.toLowerCase().startsWith(continueUrlTrusted.toLowerCase())) {
@@ -65,7 +67,6 @@ class SecondFactorAuthentication extends React.Component {
 
         if (user.guest) {
             console.log("path 1");
-            const second_fa_uuid = match.params.second_fa_uuid;
             if (second_fa_uuid && continueUrl) {
                 //We need to know if this is a new user. We use the second_fa_uuid for this
                 get2faProxyAuthz(second_fa_uuid)
@@ -95,6 +96,7 @@ class SecondFactorAuthentication extends React.Component {
         } else {
             console.log("path 4");
             this.setState({
+                secondFaUuid: second_fa_uuid,
                 continueUrl: continueUrl,
                 loading: false
             });

--- a/client/src/pages/SecondFactorAuthentication.jsx
+++ b/client/src/pages/SecondFactorAuthentication.jsx
@@ -48,6 +48,11 @@ class SecondFactorAuthentication extends React.Component {
 
     componentDidMount() {
         const {user, update, match} = this.props;
+        console.log("2fa start");
+        debugger;
+        console.log(user);
+        console.log(update);
+        console.log(match);
         if (user.guest) {
             const second_fa_uuid = match.params.second_fa_uuid;
             const urlSearchParams = new URLSearchParams(window.location.search);

--- a/client/src/pages/SecondFactorAuthentication.jsx
+++ b/client/src/pages/SecondFactorAuthentication.jsx
@@ -62,7 +62,9 @@ class SecondFactorAuthentication extends React.Component {
                             qrCode: res.qr_code_base64,
                             idp_name: res.idp_name || I18n.t("mfa.register.unknownIdp"),
                             continueUrl: continueUrl
+                            // hier ssid_needed vars toevoegen in state
                         });
+                        // hier checken of we ssid moeten doen;  zo ja, rediretc url ophalen en op de een of andere manier original_destination in sessie zetten en user redirecten
                         this.focusCode();
                     }).catch(() => this.props.history.push(`/404?eo=${ErrorOrigins.invalidSecondFactorUUID}`))
             } else {

--- a/client/src/pages/SecondFactorAuthentication.jsx
+++ b/client/src/pages/SecondFactorAuthentication.jsx
@@ -82,13 +82,6 @@ class SecondFactorAuthentication extends React.Component {
             } else {
                 this.props.history.push("/landing");
             }
-        } else if (user.second_factor_confirmed && !update) {
-            console.log("path 2");
-            if (continueUrl) {
-                window.location.href = continueUrl
-            } else {
-                this.props.history.push("/home")
-            }
         } else if (!user.second_factor_auth || update) {
             console.log("path 3");
             get2fa().then(res => {

--- a/client/src/pages/SecondFactorAuthentication.jsx
+++ b/client/src/pages/SecondFactorAuthentication.jsx
@@ -60,13 +60,7 @@ class SecondFactorAuthentication extends React.Component {
             throw new Error(`Invalid continue url: '${continueUrl}'`)
         }
 
-        console.log(user);
-        console.log(update);
-        console.log(match);
-        console.log(config);
-
         if (user.guest) {
-            console.log("path 1");
             if (second_fa_uuid && continueUrl) {
                 //We need to know if this is a new user. We use the second_fa_uuid for this
                 get2faProxyAuthz(second_fa_uuid)
@@ -84,7 +78,6 @@ class SecondFactorAuthentication extends React.Component {
                 this.props.history.push("/landing");
             }
         } else if (!user.second_factor_auth || update) {
-            console.log("path 3");
             get2fa().then(res => {
                 this.setState({
                     qrCode: res.qr_code_base64,
@@ -94,7 +87,6 @@ class SecondFactorAuthentication extends React.Component {
                 this.focusCode();
             });
         } else {
-            console.log("path 4");
             this.setState({
                 secondFaUuid: second_fa_uuid,
                 continueUrl: continueUrl,

--- a/server/api/mfa.py
+++ b/server/api/mfa.py
@@ -268,9 +268,9 @@ def do_ssid_redirect(second_fa_uuid):
     logger = ctx_logger("2fa")
 
     continue_url = query_param("continue_url", required=True)
-    session["original_destination"] = continue_url
+    session["ssid_original_destination"] = continue_url
     user = User.query.filter(User.second_fa_uuid == second_fa_uuid).one()
 
-    logger.debug(f"do_ssid_redirect: continu{continue_url}, user={user}")
+    logger.debug(f"do_ssid_redirect: continu={continue_url}, user={user}")
 
     return redirect_to_surf_secure_id(user)

--- a/server/api/mfa.py
+++ b/server/api/mfa.py
@@ -79,7 +79,6 @@ def _do_get2fa(schac_home_organisation, user_identifier):
     img.save(buffered, format="PNG")
     img_str = base64.b64encode(buffered.getvalue()).decode()
     idp_name = idp_display_name(schac_home_organisation, "en")
-    # hier ook ssid_required en sha en uid teruggeven
     return {"qr_code_base64": img_str, "secret": secret, "idp_name": idp_name}, 200
 
 
@@ -144,7 +143,6 @@ def get2fa_proxy_authz():
     user = User.query.filter(User.second_fa_uuid == second_fa_uuid).one()
     if user.second_factor_auth:
         return {}, 200
-    # hier ook ssid_required teruggeven
     return _do_get2fa(user.schac_home_organisation, user.uid)
 
 

--- a/server/api/user.py
+++ b/server/api/user.py
@@ -16,7 +16,7 @@ from onelogin.saml2.constants import OneLogin_Saml2_Constants
 from onelogin.saml2.utils import OneLogin_Saml2_Utils
 from sqlalchemy import text, or_, bindparam, String
 from sqlalchemy.orm import joinedload, selectinload
-from werkzeug.exceptions import Forbidden
+from werkzeug.exceptions import Forbidden, InternalServerError
 
 from server.api.base import json_endpoint, query_param
 from server.api.base import replace_full_text_search_boolean_mode_chars
@@ -311,7 +311,7 @@ def resume_session():
 
         # this is a configuration conflict and should never happen!
         if idp_allowed and ssid_required:
-            raise Exception(f"Both IdP-based MFA and SSID-based MFA configured for IdP '{schac_home_organisation}'")
+            raise InternalServerError(f"Both IdP-based MFA and SSID-based MFA configured for IdP '{schac_home_organisation}'")
 
         # if IdP-base MFA is set, we assume everything is handled by the IdP, and we skip all checks here
         # also skip if user has already recently performed MFA

--- a/server/api/user.py
+++ b/server/api/user.py
@@ -354,8 +354,12 @@ def _redirect_to_client(cfg, second_factor_confirmed, user):
         location = f"{cfg.base_url}/aup"
     elif not second_factor_confirmed:
         location = f"{cfg.base_url}/2fa"
+    elif "ssid_original_destination" in session:
+        location = session.pop("ssid_original_destination")
+    elif "original_destination" in session:
+        location = session.pop("original_destination")
     else:
-        location = session.get("original_destination", cfg.base_url)
+        location = cfg.base_url
 
     logger.debug(f"Redirecting user {user.uid} to {location}")
     return redirect(location)

--- a/server/api/user.py
+++ b/server/api/user.py
@@ -292,6 +292,8 @@ def resume_session():
     id_token = decode_jwt_token(encoded_id_token)
 
     idp_mfa = id_token.get("acr") == ACR_VALUES
+    if idp_mfa:
+        logger.debug(f"user {uid}: idp_mfa={idp_mfa} (ACR = '{id_token.get('acr')}')")
 
     # we're repeating some of the logic of _perform_sram_login() here
     # at least until EduTEAMS has transitioned to inserting a call to proxy_authz in the login flow for SBS itself

--- a/server/api/user.py
+++ b/server/api/user.py
@@ -23,7 +23,7 @@ from server.api.base import replace_full_text_search_boolean_mode_chars
 from server.api.ipaddress import validate_ip_networks
 
 from server.auth.mfa import ACR_VALUES, store_user_in_session, mfa_idp_allowed, \
-    surf_secure_id_required, has_valid_mfa
+    surf_secure_id_required, has_valid_mfa, decode_jwt_token
 from server.auth.security import confirm_allow_impersonation, is_admin_user, current_user_id, confirm_read_access, \
     confirm_collaboration_admin, confirm_organisation_admin, current_user, confirm_write_access
 from server.auth.ssid import AUTHN_REQUEST_ID, saml_auth, redirect_to_surf_secure_id, USER_UID
@@ -288,11 +288,16 @@ def resume_session():
         logger.info(f"Updating user {user.uid} with new claims / updated at")
         add_user_claims(user_info_json, uid, user)
 
+    encoded_id_token = token_json["id_token"]
+    id_token = decode_jwt_token(encoded_id_token)
+
+    idp_mfa = id_token.get("acr") == ACR_VALUES
+
     # we're repeating some of the logic of _perform_sram_login() here
     # at least until EduTEAMS has transitioned to inserting a call to proxy_authz in the login flow for SBS itself
     #
     # no need to repeat this logic if we already have made a decision before
-    if not user.ssid_required and not has_valid_mfa(user):
+    if not idp_mfa and not user.ssid_required and not has_valid_mfa(user):
         schac_home_organisation = user.schac_home_organisation
         home_organisation_uid = user_info_json.get('uid', None)
 
@@ -325,14 +330,8 @@ def resume_session():
         db.session.commit()
         return redirect_to_surf_secure_id(user)
 
-    # TODO: we're not using ACR values from OIDC at the moment.  Reintroduce this later
-    # encoded_id_token = token_json["id_token"]
-    # id_token = decode_jwt_token(encoded_id_token)
-
-    # no_mfa_required = not oidc_config.second_factor_authentication_required
-    # idp_mfa = id_token.get("acr") == ACR_VALUES
-
-    second_factor_confirmed = not fallback_required
+    no_mfa_required = not oidc_config.second_factor_authentication_required
+    second_factor_confirmed = no_mfa_required or not fallback_required
     if second_factor_confirmed:
         user.last_login_date = datetime.datetime.now()
 

--- a/server/api/user_saml.py
+++ b/server/api/user_saml.py
@@ -216,6 +216,7 @@ def proxy_authz():
         if status == SECOND_FA_REQUIRED:
             # Internal contract, in case of SECOND_FA_REQUIRED we get the User instance returned
             user = service_name
+            user.second_factor_confirmed = False
             user.second_fa_uuid = str(uuid.uuid4())
             db.session.merge(user)
             db.session.commit()

--- a/server/api/user_saml.py
+++ b/server/api/user_saml.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from urllib.parse import urlencode
 
 from flask import Blueprint, current_app, request as current_request
+from werkzeug.exceptions import InternalServerError
 
 from server.api.base import json_endpoint, send_error_mail
 from server.api.service_aups import has_agreed_with
@@ -154,7 +155,7 @@ def _do_attributes(uid, service_entity_id, not_authorized_func, authorized_func,
 
         # this is a configuration conflict and should never happen!
         if idp_allowed and ssid_required:
-            raise Exception(f"Both IdP-based MFA and SSID-based MFA configured for IdP '{schac_home_organisation}'")
+            raise InternalServerError(f"Both IdP-based MFA and SSID-based MFA configured for IdP '{schac_home_organisation}'")
 
         # if IdP-base MFA is set, we assume everything is handled by the IdP, and we skip all checks here
         # also skip if user has already recently performed MFA

--- a/server/api/user_saml.py
+++ b/server/api/user_saml.py
@@ -55,6 +55,7 @@ def _perform_sram_login(uid, home_organisation_uid, schac_home_organisation, iss
     if require_2fa:
         idp_allowed = mfa_idp_allowed(user, schac_home_organisation, issuer_id)
         ssid_required = surf_secure_id_required(user, schac_home_organisation, issuer_id)
+        fallback_required = not idp_allowed and not ssid_required and current_app.app_config.mfa_fallback_enabled
 
         # this is a configuration conflict and should never happen!
         if idp_allowed and ssid_required:
@@ -62,7 +63,7 @@ def _perform_sram_login(uid, home_organisation_uid, schac_home_organisation, iss
 
         # if IdP-base MFA is set, we assume everything is handled by the IdP, and we skip all checks here
         # also skip if user has already recently performed MFA
-        if not idp_allowed and not has_valid_mfa(user):
+        if not idp_allowed and (ssid_required or fallback_required) and not has_valid_mfa(user):
             base_url = current_app.app_config.base_url
             if ssid_required:
                 user.ssid_required = True
@@ -147,6 +148,7 @@ def _do_attributes(uid, service_entity_id, not_authorized_func, authorized_func,
     if require_2fa:
         idp_allowed = mfa_idp_allowed(user, schac_home_organisation, issuer_id)
         ssid_required = surf_secure_id_required(user, schac_home_organisation, issuer_id)
+        fallback_required = not idp_allowed and not ssid_required and current_app.app_config.mfa_fallback_enabled
 
         # this is a configuration conflict and should never happen!
         if idp_allowed and ssid_required:
@@ -154,7 +156,7 @@ def _do_attributes(uid, service_entity_id, not_authorized_func, authorized_func,
 
         # if IdP-base MFA is set, we assume everything is handled by the IdP, and we skip all checks here
         # also skip if user has already recently performed MFA
-        if not idp_allowed and not has_valid_mfa(user):
+        if not idp_allowed and (ssid_required or fallback_required) and not has_valid_mfa(user):
             if ssid_required:
                 user.ssid_required = True
                 user.home_organisation_uid = home_organisation_uid

--- a/server/api/user_saml.py
+++ b/server/api/user_saml.py
@@ -62,7 +62,8 @@ def _perform_sram_login(uid, home_organisation_uid, schac_home_organisation, iss
 
         # this is a configuration conflict and should never happen!
         if idp_allowed and ssid_required:
-            raise Exception(f"Both IdP-based MFA and SSID-based MFA configured for IdP '{schac_home_organisation}'")
+            raise InternalServerError("Both IdP-based MFA and SSID-based MFA configured "
+                                      f"for IdP '{schac_home_organisation}'")
 
         # if IdP-base MFA is set, we assume everything is handled by the IdP, and we skip all checks here
         # also skip if user has already recently performed MFA

--- a/server/api/user_saml.py
+++ b/server/api/user_saml.py
@@ -43,6 +43,8 @@ custom_saml_mapping = {
 def _perform_sram_login(uid, home_organisation_uid, schac_home_organisation, issuer_id, require_2fa=True):
     logger = ctx_logger("user_api")
 
+    logger.debug("SBS login flow")
+
     user = User.query.filter(User.uid == uid).first()
     if not user:
         logger.debug("Creating new user in sram_login")

--- a/server/auth/mfa.py
+++ b/server/auth/mfa.py
@@ -93,33 +93,36 @@ def eligible_users_to_reset_token(user):
     return user_information
 
 
-def _idp_configured_or_valid_mfa(user, identity_providers, valid_sso_negates, action, schac_home=None, entity_id=None):
+def _idp_configured(user, identity_providers, action, schac_home=None, entity_id=None):
     entity_id_allowed = entity_id and [idp for idp in identity_providers if idp.entity_id == entity_id.lower()]
     schac_home_allowed = schac_home and [idp for idp in identity_providers if idp.schac_home == schac_home.lower()]
-    last_login_date = user.last_login_date
-    minutes_ago = datetime.now() - timedelta(hours=0, minutes=int(current_app.app_config.mfa_sso_time_in_minutes))
-    valid_mfa_sso = last_login_date and last_login_date > minutes_ago
 
-    if valid_sso_negates:
-        result = (entity_id_allowed or schac_home_allowed) and not valid_mfa_sso
-    else:
-        result = entity_id_allowed or schac_home_allowed or valid_mfa_sso
+    result = entity_id_allowed or schac_home_allowed
 
     logger = ctx_logger("user_api")
-    logger.debug(f"{action}: {result} (entity_id_allowed={entity_id_allowed}, schac_home_allowed={schac_home_allowed}, "
-                 f"valid_mfa_sso={valid_mfa_sso}, entity_id={entity_id}, schac_home={schac_home}, "
-                 f"last_login={minutes_ago} minutes ago")
+    logger.debug(f"{action}: {bool(result)} (entity_id_allowed={entity_id_allowed}, "
+                 f"schac_home_allowed={schac_home_allowed}, "
+                 f"entity_id={entity_id}, schac_home={schac_home}")
 
     return bool(result)
 
 
+def has_valid_mfa(user):
+    last_login_date = user.last_login_date
+    login_sso_cutoff = timedelta(hours=0, minutes=int(current_app.app_config.mfa_sso_time_in_minutes))
+    valid_mfa_sso = last_login_date and datetime.now() - user.last_login_date < login_sso_cutoff
+
+    logger = ctx_logger("user_api")
+    logger.debug(f"has_valid_mfa: {valid_mfa_sso} (user={user}, last_login={last_login_date}")
+
+    return valid_mfa_sso
+
+
 def mfa_idp_allowed(user, schac_home=None, entity_id=None):
     allowed_identity_providers = current_app.app_config.mfa_idp_allowed
-    return _idp_configured_or_valid_mfa(user, allowed_identity_providers, False, "mfa_idp_allowed", schac_home,
-                                        entity_id)
+    return _idp_configured(user, allowed_identity_providers, "mfa_idp_allowed", schac_home, entity_id)
 
 
 def surf_secure_id_required(user, schac_home=None, entity_id=None):
     ssid_identity_providers = current_app.app_config.ssid_identity_providers
-    return _idp_configured_or_valid_mfa(user, ssid_identity_providers, True, "surf_secure_id_required", schac_home,
-                                        entity_id)
+    return _idp_configured(user, ssid_identity_providers, "surf_secure_id_required", schac_home, entity_id)

--- a/server/auth/urls.py
+++ b/server/auth/urls.py
@@ -5,6 +5,7 @@ white_listing = [
     "/api/mfa/get2fa_proxy_authz",
     "/api/mfa/jwks",
     "/api/mfa/sfo",
+    "/api/mfa/ssid_start",
     "/api/mfa/verify2fa_proxy_authz",
     "/api/mock",
     "/api/organisation_invitations/find_by_hash",

--- a/server/config/test_config.yml
+++ b/server/config/test_config.yml
@@ -187,15 +187,20 @@ ldap:
   url: "ldap://ldap.example.com/dc=example,dc=com"
   bind_account: "cn=admin,dc=entity_id,dc=services,dc=sram-tst,dc=surf,dc=nl"
 
-# Lower case schachome organisations / entity ID's allowed skipping MFA
+# A MFA login in a different flow is valid for X minutes
+mfa_sso_time_in_minutes: 10
+
+# whether to require TOTP for users form IdPs that match neither mfa_idp_allowed
+# nor ssid_identity_providers
+mfa_fallback_enabled: true
+
+# Lower case schachome organisations / entity ID's allowed skipping MFA;
+# MFA is supposed to be handled at the IdP for these entities
 mfa_idp_allowed:
   - schac_home: "idp.test"
     entity_id: "https://idp.test"
   - schac_home: "erroridp.example.edu"
     entity_id: "https://erroridp.example.edu"
-
-# A MFA login in a different flow is valid for X minutes
-mfa_sso_time_in_minutes: 10
 
 # Lower case schachome organisations / entity ID's where SURFSecure ID is used for step-up
 # If this feature is no longer needed, just replace the value with an empty list []

--- a/server/config/test_config.yml
+++ b/server/config/test_config.yml
@@ -191,6 +191,8 @@ ldap:
 mfa_idp_allowed:
   - schac_home: "idp.test"
     entity_id: "https://idp.test"
+  - schac_home: "erroridp.example.edu"
+    entity_id: "https://erroridp.example.edu"
 
 # A MFA login in a different flow is valid for X minutes
 mfa_sso_time_in_minutes: 10
@@ -200,6 +202,8 @@ mfa_sso_time_in_minutes: 10
 ssid_identity_providers:
   - schac_home: "ssid.org"
     entity_id: "https://ssid.org"
+  - schac_home: "erroridp.example.edu"
+    entity_id: "https://erroridp.example.edu"
 
 ssid_config_folder: saml_test
 

--- a/server/test/api/test_mfa.py
+++ b/server/test/api/test_mfa.py
@@ -3,8 +3,10 @@ import pyotp
 import responses
 from flask import current_app
 
+from server.auth.ssid import saml_auth
 from server.db.domain import User
 from server.test.abstract_test import AbstractTest
+from server.test.seed import service_mail_entity_id, sarah_name
 from server.tools import read_file
 
 
@@ -32,6 +34,19 @@ class TestMfa(AbstractTest):
 
         mary = User.query.filter(User.uid == "urn:mary").first()
         self.assertEqual(secret, mary.second_factor_auth)
+
+    def test_ssid_scenario(self):
+        # initiate proxy_authz call to initialize 2fa
+        res = self.post("/api/users/proxy_authz", response_status_code=200,
+                        body={"user_id": "urn:sarah", "service_id": service_mail_entity_id, "issuer_id": "issuer.com",
+                              "uid": "sarah", "homeorganization": "ssid.org"})
+        sarah = self.find_entity_by_name(User, sarah_name)
+
+        # start the ssid
+        res = self.get(f"/api/mfa/ssid_start/{sarah.second_fa_uuid}", query_data={"continue_url": "https://foo.bar"},
+                       response_status_code=302)
+        saml_sso_url = saml_auth().get_sso_url()
+        self.assertTrue(res.location.startswith(saml_sso_url))
 
     def test_2fa_invalid_totp(self):
         AbstractTest.set_second_factor_auth("urn:mary")

--- a/server/test/api/test_mfa.py
+++ b/server/test/api/test_mfa.py
@@ -48,6 +48,16 @@ class TestMfa(AbstractTest):
         saml_sso_url = saml_auth().get_sso_url()
         self.assertTrue(res.location.startswith(saml_sso_url))
 
+        # ssid response
+        xml_authn_b64 = self.get_authn_response("response.ok.xml")
+        res = self.client.post("/api/users/acs", headers={},
+                               data={"SAMLResponse": xml_authn_b64,
+                                     "RelayState": "http://localhost:8080/api/users/acs"},
+                               content_type="application/x-www-form-urlencoded")
+
+        self.assertEqual(302, res.status_code)
+        self.assertEqual("https://foo.bar", res.location)
+
     def test_2fa_invalid_totp(self):
         AbstractTest.set_second_factor_auth("urn:mary")
 

--- a/server/test/api/test_user.py
+++ b/server/test/api/test_user.py
@@ -370,7 +370,7 @@ class TestUser(AbstractTest):
                       status=200)
         responses.add(responses.GET, current_app.app_config.oidc.jwks_endpoint,
                       read_file("test/data/public.json"), status=200)
-        res = self.get("/api/users/resume-session", query_data={"code": "123456"}, response_status_code=500)
+        self.get("/api/users/resume-session", query_data={"code": "123456"}, response_status_code=500)
 
     @responses.activate
     def test_authorization_resume_redirect(self):

--- a/server/test/api/test_user_saml.py
+++ b/server/test/api/test_user_saml.py
@@ -269,3 +269,19 @@ class TestUserSaml(AbstractTest):
         self.assertEqual(res["status"]["result"], "authorized")
         attrs = res["attributes"]
         self.assertListEqual(["sarah"], attrs["uid"])
+
+    def test_proxy_authz_mfa_faulty_config(self):
+        res = self.post("/api/users/proxy_authz", response_status_code=500,
+                        body={"user_id": "urn:sarah",
+                              "service_id": service_mail_entity_id,
+                              "issuer_id": "https://erroridp.example.edu",
+                              "uid": "sarah",
+                              "homeorganization": "erroridp.example.edu"})
+        self.assertTrue(res["error"])
+        res = self.post("/api/users/proxy_authz", response_status_code=500,
+                        body={"user_id": "urn:sarah",
+                              "service_id": self.app.app_config.oidc.sram_service_entity_id,
+                              "issuer_id": "https://erroridp.example.edu",
+                              "uid": "sarah",
+                              "homeorganization": "erroridp.example.edu"})
+        self.assertTrue(res["error"])

--- a/server/test/api/test_user_saml.py
+++ b/server/test/api/test_user_saml.py
@@ -38,6 +38,8 @@ class TestUserSaml(AbstractTest):
 
         sarah = self.find_entity_by_name(User, sarah_name)
         self.assertTrue(sarah.ssid_required)
+        self.assertEqual("ssid.org", sarah.schac_home_organisation)
+        self.assertEqual("sarah", sarah.home_organisation_uid)
 
     def test_proxy_authz_including_groups(self):
         self.add_service_aup_to_user("urn:jane", service_network_entity_id)

--- a/server/test/api/test_user_saml.py
+++ b/server/test/api/test_user_saml.py
@@ -278,6 +278,7 @@ class TestUserSaml(AbstractTest):
                               "uid": "sarah",
                               "homeorganization": "erroridp.example.edu"})
         self.assertTrue(res["error"])
+
         res = self.post("/api/users/proxy_authz", response_status_code=500,
                         body={"user_id": "urn:sarah",
                               "service_id": self.app.app_config.oidc.sram_service_entity_id,

--- a/server/test/api/test_user_saml.py
+++ b/server/test/api/test_user_saml.py
@@ -28,19 +28,6 @@ class TestUserSaml(AbstractTest):
         self.assertListEqual(["sarah"], attrs["uid"])
         self.assertIsNotNone(attrs["sshkey"][0])
 
-    def test_proxy_authz_ssid_required(self):
-        self.add_service_aup_to_user("urn:sarah", service_mail_entity_id)
-
-        res = self.post("/api/users/proxy_authz", response_status_code=200,
-                        body={"user_id": "urn:sarah", "service_id": service_mail_entity_id, "issuer_id": "issuer.com",
-                              "uid": "sarah", "homeorganization": "ssid.org"})
-        self.assertEqual(res["status"]["result"], "interrupt")
-
-        sarah = self.find_entity_by_name(User, sarah_name)
-        self.assertTrue(sarah.ssid_required)
-        self.assertEqual("ssid.org", sarah.schac_home_organisation)
-        self.assertEqual("sarah", sarah.home_organisation_uid)
-
     def test_proxy_authz_including_groups(self):
         self.add_service_aup_to_user("urn:jane", service_network_entity_id)
         self.login_user_2fa("urn:jane")
@@ -103,23 +90,6 @@ class TestUserSaml(AbstractTest):
         parameters = urlencode({"service_id": network_service.uuid4, "service_name": network_service.name})
         self.assertEqual(res["status"]["redirect_url"], f"http://localhost:3000/service-aup?{parameters}")
 
-    def test_proxy_authz_no_2fa(self):
-        res = self.post("/api/users/proxy_authz", response_status_code=200,
-                        body={"user_id": "urn:sarah", "service_id": service_mail_entity_id, "issuer_id": "nope",
-                              "uid": "sarah", "homeorganization": "example.com"})
-        sarah = self.find_entity_by_name(User, sarah_name)
-        self.assertEqual(res["status"]["result"], "interrupt")
-        self.assertEqual(res["status"]["redirect_url"], f"http://localhost:3000/2fa/{sarah.second_fa_uuid}")
-
-    def test_proxy_authz_allowed_idp(self):
-        self.add_service_aup_to_user("urn:sarah", service_mail_entity_id)
-
-        res = self.post("/api/users/proxy_authz", response_status_code=200,
-                        body={"user_id": "urn:sarah", "service_id": service_mail_entity_id,
-                              "issuer_id": "https://idp.test", "uid": "sarah", "homeorganization": "example.com"})
-        attrs = res["attributes"]
-        self.assertListEqual(["sarah"], attrs["uid"])
-
     def test_proxy_authz_no_user(self):
         res = self.post("/api/users/proxy_authz", body={"user_id": "urn:nope", "service_id": service_mail_entity_id,
                                                         "issuer_id": "https://idp.test", "uid": "sarah",
@@ -144,7 +114,10 @@ class TestUserSaml(AbstractTest):
         self.assertEqual("unauthorized", res["status"]["result"])
         self.assertEqual(SERVICE_NOT_CONNECTED, res["status"]["error_status"])
 
-    def test_proxy_authz_sram_login(self):
+    #
+    # MFA scenarios:
+    # logins on SBS
+    def test_proxy_authz_mfa_sbs_totp(self):
         res = self.post("/api/users/proxy_authz", response_status_code=200,
                         body={"user_id": "urn:sarah",
                               "service_id": self.app.app_config.oidc.sram_service_entity_id,
@@ -158,7 +131,7 @@ class TestUserSaml(AbstractTest):
         self.assertEqual(status_["error_status"], SECOND_FA_REQUIRED)
         self.assertEqual(status_["redirect_url"], f"http://localhost:3000/2fa/{sarah.second_fa_uuid}")
 
-    def test_proxy_authz_sram_login_new_user(self):
+    def test_proxy_authz_mfa_sbs_totp_new_user(self):
         res = self.post("/api/users/proxy_authz", response_status_code=200,
                         body={"user_id": "urn:new_user",
                               "service_id": self.app.app_config.oidc.sram_service_entity_id,
@@ -171,22 +144,7 @@ class TestUserSaml(AbstractTest):
         self.assertEqual("example.com", new_user.schac_home_organisation)
         self.assertEqual("sarah", new_user.home_organisation_uid)
 
-    def test_proxy_authz_sram_login_ssid_required(self):
-        self.add_service_aup_to_user("urn:sarah", service_mail_entity_id)
-
-        res = self.post("/api/users/proxy_authz", response_status_code=200,
-                        body={"user_id": "urn:sarah",
-                              "service_id": self.app.app_config.oidc.sram_service_entity_id,
-                              "issuer_id": "idp",
-                              "uid": "sarah",
-                              "homeorganization": "ssid.org"})
-        status_ = res["status"]
-        self.assertEqual(status_["result"], "authorized")
-
-        sarah = self.find_entity_by_name(User, sarah_name)
-        self.assertTrue(sarah.ssid_required)
-
-    def test_proxy_authz_sram_login_no_2fa_required(self):
+    def test_proxy_authz_mfa_sbs_totp_sso(self):
         self.login_user_2fa("urn:sarah")
 
         res = self.post("/api/users/proxy_authz", response_status_code=200,
@@ -200,3 +158,114 @@ class TestUserSaml(AbstractTest):
 
         sarah = self.find_entity_by_name(User, sarah_name)
         self.assertFalse(sarah.ssid_required)
+
+    def test_proxy_authz_mfa_sbs_ssid(self):
+        res = self.post("/api/users/proxy_authz", response_status_code=200,
+                        body={"user_id": "urn:sarah",
+                              "service_id": self.app.app_config.oidc.sram_service_entity_id,
+                              "issuer_id": "https://ssid.org",
+                              "uid": "sarah",
+                              "homeorganization": "ssid.org"})
+        status_ = res["status"]
+        sarah = self.find_entity_by_name(User, sarah_name)
+        self.assertEqual(status_["result"], "interrupt")
+        self.assertEqual(res["status"]["redirect_url"],
+                         f"http://localhost:3000/api/mfa/ssid_start/{sarah.second_fa_uuid}")
+        self.assertTrue(sarah.ssid_required)
+
+    def test_proxy_authz_mfa_sbs_ssid_sso(self):
+        self.login_user_2fa("urn:sarah")
+
+        res = self.post("/api/users/proxy_authz", response_status_code=200,
+                        body={"user_id": "urn:sarah",
+                              "service_id": self.app.app_config.oidc.sram_service_entity_id,
+                              "issuer_id": "https://ssid.org",
+                              "uid": "sarah",
+                              "homeorganization": "ssid.org"})
+        sarah = self.find_entity_by_name(User, sarah_name)
+        self.assertEqual(res["status"]["result"], "authorized")
+        self.assertFalse(sarah.ssid_required)
+
+    def test_proxy_authz_mfa_sbs_idp(self):
+        res = self.post("/api/users/proxy_authz", response_status_code=200,
+                        body={"user_id": "urn:sarah",
+                              "service_id": self.app.app_config.oidc.sram_service_entity_id,
+                              "issuer_id": "https://idp.test",
+                              "uid": "sarah",
+                              "homeorganization": "idp.test"})
+        sarah = self.find_entity_by_name(User, sarah_name)
+        self.assertEqual(res["status"]["result"], "authorized")
+        self.assertFalse(sarah.ssid_required)
+
+    # MFA scenarios:
+    # login on services
+    def test_proxy_authz_mfa_service_totp(self):
+        res = self.post("/api/users/proxy_authz", response_status_code=200,
+                        body={"user_id": "urn:sarah",
+                              "service_id": service_mail_entity_id,
+                              "issuer_id": "nope",
+                              "uid": "sarah",
+                              "homeorganization": "example.com"})
+        sarah = self.find_entity_by_name(User, sarah_name)
+        self.assertEqual(res["status"]["result"], "interrupt")
+        self.assertEqual(res["status"]["redirect_url"], f"http://localhost:3000/2fa/{sarah.second_fa_uuid}")
+
+    def test_proxy_authz_mfa_service_totp_sso(self):
+        self.add_service_aup_to_user("urn:sarah", service_mail_entity_id)
+        self.login_user_2fa("urn:sarah")
+
+        res = self.post("/api/users/proxy_authz", response_status_code=200,
+                        body={"user_id": "urn:sarah",
+                              "service_id": service_mail_entity_id,
+                              "issuer_id": "nope",
+                              "uid": "sarah",
+                              "homeorganization": "example.com"})
+        sarah = self.find_entity_by_name(User, sarah_name)
+        self.assertEqual(res["status"]["result"], "authorized")
+        self.assertFalse(sarah.ssid_required)
+
+    def test_proxy_authz_mfa_service_ssid(self):
+        res = self.post("/api/users/proxy_authz", response_status_code=200,
+                        body={"user_id": "urn:sarah",
+                              "service_id": service_mail_entity_id,
+                              "issuer_id": "https://ssid.org",
+                              "uid": "sarah",
+                              "homeorganization": "ssid.org"})
+        sarah = self.find_entity_by_name(User, sarah_name)
+
+        self.assertEqual(res["status"]["result"], "interrupt")
+        self.assertEqual(res["status"]["redirect_url"],
+                         f"http://localhost:3000/api/mfa/ssid_start/{sarah.second_fa_uuid}")
+
+        sarah = self.find_entity_by_name(User, sarah_name)
+        self.assertTrue(sarah.ssid_required)
+        self.assertEqual("ssid.org", sarah.schac_home_organisation)
+        self.assertEqual("sarah", sarah.home_organisation_uid)
+
+    def test_proxy_authz_mfa_service_ssid_sso(self):
+        self.add_service_aup_to_user("urn:sarah", service_mail_entity_id)
+        self.login_user_2fa("urn:sarah")
+
+        res = self.post("/api/users/proxy_authz", response_status_code=200,
+                        body={"user_id": "urn:sarah",
+                              "service_id": service_mail_entity_id,
+                              "issuer_id": "https://ssid.org",
+                              "uid": "sarah",
+                              "homeorganization": "ssid.org"})
+        sarah = self.find_entity_by_name(User, sarah_name)
+
+        self.assertEqual(res["status"]["result"], "authorized")
+        self.assertFalse(sarah.ssid_required)
+
+    def test_proxy_authz_mfa_service_idp(self):
+        self.add_service_aup_to_user("urn:sarah", service_mail_entity_id)
+
+        res = self.post("/api/users/proxy_authz", response_status_code=200,
+                        body={"user_id": "urn:sarah",
+                              "service_id": service_mail_entity_id,
+                              "issuer_id": "https://idp.test",
+                              "uid": "sarah",
+                              "homeorganization": "idp.test"})
+        self.assertEqual(res["status"]["result"], "authorized")
+        attrs = res["attributes"]
+        self.assertListEqual(["sarah"], attrs["uid"])


### PR DESCRIPTION
Specifically, we now support 6 (!) different flows for MFA:
 - login to SP via proxy_authz via SSID
 - login to SP via proxy_authz via TOTP 
 - login to SP via proxy_authz without MFA (assumed to have been handled by IdP)
 - login to SBS via proxy_authz via SSID
 - login to SBS via proxy_authz via TOTP 
 - login to SBS via proxy_authz without MFA (assumed to have been handled by IdP)
 - direct login to SBS (no proxy_authz) via SSID
 - direct login to SBS (no proxy_authz) via TOTP 
 - direct login to SBS (no proxy_authz) without MFA (assumed to have been handled by IdP)
 - direct login to SBS (no proxy_authz) for IdPs that explicitly set an ACR 

Also introduces a feature toggle `mfa_fallback_enabled` to enable/disable fallback MFA.