### PR TITLE
Fix issue where it was impossible to connect a service to a collaboration 

### DIFF
--- a/server/api/collaborations_services.py
+++ b/server/api/collaborations_services.py
@@ -20,7 +20,7 @@ def connect_service_collaboration(service_id, collaboration_id, force=False):
     organisation = Collaboration.query.get(collaboration_id).organisation
     org_allowed = organisation in service.allowed_organisations
     org_automatic_allowed = organisation in service.automatic_connection_allowed_organisations
-    if not org_allowed and not org_automatic_allowed and not service.access_allowed_for_all:
+    if not org_allowed and not org_automatic_allowed and not service.automatic_connection_allowed:
         raise BadRequest("not_allowed_organisation")
 
     allowed_to_connect = service.automatic_connection_allowed or org_automatic_allowed

--- a/server/test/seed.py
+++ b/server/test/seed.py
@@ -332,7 +332,7 @@ def seed(db, app_config, skip_seed=False, perf_test=False):
                       description="Network enabling service SSH access", address="Some address",
                       uri="https://uri.net", identity_type="SSH KEY", accepted_user_policy="https://aup.org",
                       contact_email="help@network.com", logo=read_image("network.jpeg"),
-                      public_visible=False, automatic_connection_allowed=True, abbreviation="network",
+                      public_visible=False, automatic_connection_allowed=False, abbreviation="network",
                       allowed_organisations=[uuc], privacy_policy="https://privacy.org",
                       token_enabled=True, token_validity_days=365, security_email="sec@org.nl",
                       scim_enabled=True, scim_url="http://localhost:8080/api/scim_mock", scim_bearer_token="secret",


### PR DESCRIPTION
When a Service was set to "allow automatic connections to all Orgs", it was not possible anymore in v44 to connect this service to a CO.  Pressing "Connect to collaboration" lead to:
```
Bad news. An error occurred in Acceptatie at 2023-04-20 13:23:12.531458 for user arnout.terpstra@surfnet.nl:

Traceback (most recent call last):
  File "/opt/sbs/sbs/server/api/base.py", line 167, in wrapper
    body, status = f(*args, **kwargs)
  File "/opt/sbs/sbs/server/api/collaborations_services.py", line 60, in add_collaborations_services
    count = connect_service_collaboration(service_id, collaboration_id)
  File "/opt/sbs/sbs/server/api/collaborations_services.py", line 24, in connect_service_collaboration
    raise BadRequest(f"not_allowed_organisation (service={service_id}, co={collaboration_id}, org_allowed={org_allowed}, org_automatic_allowed={org_automatic_allowed}, access_allowed_for_all={service.access_allowed_for_all})")
werkzeug.exceptions.BadRequest: 400 Bad Request: BadRequest: http://acc.sram.surf.nl/api/collaborations_services. IP: 145.90.230.178, 10.16.0.20. not_allowed_organisation (org_allowed=False, org_automatic_allowed=False, access_allowed_for_all=False)
```

I'm pretty sure this fixes the issue, but I need to test this thoroughly and also make sure that the tests cover all 5 possibilities (allow all automatic, allow all requests, allow org automatic, allow org request, deny)