### PR TITLE
Fix the case when a new user need to do SSID (fixes: #743)

### DIFF
--- a/server/api/aup.py
+++ b/server/api/aup.py
@@ -31,7 +31,7 @@ def agreed_aup():
     session["user"] = {**session["user"], **{"user_accepted_aup": True}}
 
     _, location = get_redirect(current_app.app_config, user_accepted_aup=True,
-                            second_factor_confirmed=session["user"]["second_factor_confirmed"])
+                               second_factor_confirmed=session["user"]["second_factor_confirmed"])
 
     ctx_logger("redirect").debug(f"Redirecting user {user_id} to {location}")
 

--- a/server/api/aup.py
+++ b/server/api/aup.py
@@ -30,7 +30,7 @@ def agreed_aup():
         save(Aup, custom_json=jsonify(aup).json, allow_child_cascades=False)
     session["user"] = {**session["user"], **{"user_accepted_aup": True}}
 
-    location = get_redirect(current_app.app_config, user_accepted_aup=True,
+    _, location = get_redirect(current_app.app_config, user_accepted_aup=True,
                             second_factor_confirmed=session["user"]["second_factor_confirmed"])
 
     ctx_logger("redirect").debug(f"Redirecting user {user_id} to {location}")

--- a/server/api/aup.py
+++ b/server/api/aup.py
@@ -1,9 +1,11 @@
 from flask import Blueprint, current_app, jsonify, session
 
 from server.api.base import json_endpoint
+from server.api.user import get_redirect
 from server.auth.security import current_user_id
 from server.db.domain import Aup
 from server.db.models import save
+from server.logger.context_logger import ctx_logger
 
 aup_api = Blueprint("aup_api", __name__, url_prefix="/api/aup")
 
@@ -27,5 +29,10 @@ def agreed_aup():
         aup = Aup(au_version=version, user_id=user_id)
         save(Aup, custom_json=jsonify(aup).json, allow_child_cascades=False)
     session["user"] = {**session["user"], **{"user_accepted_aup": True}}
-    location = session.get("original_destination", current_app.app_config.base_url)
+
+    location = get_redirect(current_app.app_config, user_accepted_aup=True,
+                            second_factor_confirmed=session["user"]["second_factor_confirmed"])
+
+    ctx_logger("redirect").debug(f"Redirecting user {user_id} to {location}")
+
     return {"location": location}, 201

--- a/server/api/user.py
+++ b/server/api/user.py
@@ -369,6 +369,16 @@ def redirect_to_client(cfg, second_factor_confirmed, user):
     db.session.commit()
     user_accepted_aup = user.has_agreed_with_aup()
     store_user_in_session(user, second_factor_confirmed, user_accepted_aup)
+
+    status, location = get_redirect(cfg, user_accepted_aup, second_factor_confirmed)
+    logger.debug(f"Redirecting user {user.uid} to {location}")
+
+    log_user_login(SBS_LOGIN, True, user, user.uid, None, None, status=status)
+
+    return redirect(location)
+
+
+def get_redirect(cfg, user_accepted_aup, second_factor_confirmed):
     if not user_accepted_aup:
         location = f"{cfg.base_url}/aup"
         status = "AUP_NOT_AGREED"
@@ -385,11 +395,7 @@ def redirect_to_client(cfg, second_factor_confirmed, user):
         location = cfg.base_url
         status = "BASE_URL"
 
-    logger.debug(f"Redirecting user {user.uid} to {location}")
-
-    log_user_login(SBS_LOGIN, True, user, user.uid, None, None, status=status)
-
-    return redirect(location)
+    return status, location
 
 
 def _do_delete_user(user_id, send_mail_account_deletion=True):

--- a/server/test/api/test_mfa.py
+++ b/server/test/api/test_mfa.py
@@ -66,7 +66,7 @@ class TestMfa(AbstractTest):
                               "user_email": "new_user@example.edu"})
         # check that result is interrupt
         self.assertEqual(res["status"]["result"], "interrupt")
-        self.assertIn('/api/mfa/ssid_start/', res["status"]["redirect_url"])
+        self.assertIn(self.app.app_config.base_server_url + '/api/mfa/ssid_start/', res["status"]["redirect_url"])
 
         # check provisioning of new user
         new_user = User.query.filter(User.uid == "urn:new_user").first()

--- a/server/test/api/test_mfa.py
+++ b/server/test/api/test_mfa.py
@@ -58,7 +58,7 @@ class TestMfa(AbstractTest):
         self.assertEqual(302, res.status_code)
         self.assertEqual("https://foo.bar", res.location)
 
-    def test_ssid_new_user(self):
+    def test_ssid_scenario_new_user(self):
         # initiate proxy_authz call to provision user and initialize 2fa
         res = self.post("/api/users/proxy_authz", response_status_code=200,
                         body={"user_id": "urn:new_user", "service_id": self.app.app_config.oidc.sram_service_entity_id,
@@ -88,7 +88,7 @@ class TestMfa(AbstractTest):
                                content_type="application/x-www-form-urlencoded")
 
         self.assertEqual(302, res.status_code)
-        self.assertEqual(self.app.app_config.base_url+"/aup", res.location)
+        self.assertEqual(self.app.app_config.base_url + "/aup", res.location)
 
         res = self.post("/api/aup/agree", with_basic_auth=False)
         self.assertEqual("https://foo.bar", res["location"])


### PR DESCRIPTION
When a new user is sent to SSID, they are sent to the AUP screen after completing SSID stepup, and are never sent back to the continue endpoint.