### PR TITLE
Allow for updates to group properties from Org API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,9 @@ pip-upgrade requirements/test.txt --dry-run
 
 See the /config/saml_test configuration and the https://github.com/SURFscz/SCZ-deploy project
 
-### [flash](#flash)
+### [flask](#flask)
 
-To open a flash terminal session:
+To open a flask terminal session:
 
 ```bash
 source .venv/bin/activate

--- a/server/api/group.py
+++ b/server/api/group.py
@@ -274,7 +274,7 @@ def api_add_group_membership(group_identifier):
         .filter(Group.identifier == group_identifier) \
         .one()
 
-    if not organisation or organisation.id != group.collaboration.organisation_id:
+    if organisation.id != group.collaboration.organisation_id:
         raise Forbidden()
 
     user = User.query \

--- a/server/swagger/public/paths/update_group.yml
+++ b/server/swagger/public/paths/update_group.yml
@@ -1,0 +1,52 @@
+summary: "Post a new group."
+description: "Save a new group."
+
+tags:
+  - "Organisation"
+
+consumes:
+  - "application/json"
+
+produces:
+  - "application/json"
+
+security:
+  - Organisation: [ 'Authorization' ]
+
+parameters:
+  - name: Authorization
+    in: header
+    description: Bearer API key
+    required: true
+    schema:
+      type: string
+      example: "Bearer Am4Hp7GBO2lMseskWHRmEtE3DWD-VxZZ3qwMkNPv6qZ8"
+  - name: group_identifier
+    in: path
+    description: "Unique identifier of the group"
+    required: true
+    schema:
+      type: string
+      format: uuid
+      example: "301ee8e6-b5d1-40b5-a27e-47611f803371"
+  - name: group
+    in: body
+    description: "The group attributes"
+    required: true
+    schema:
+      $ref: '/swagger/schemas/GroupUpdate.yaml'
+
+responses:
+  201:
+    description: Created collaboration
+    schema:
+      $ref: '/swagger/schemas/GroupCreateResponse.yaml'
+  401:
+    schema:
+      $ref: '/swagger/components/responses/Unauthorized.yaml'
+  403:
+    schema:
+      $ref: '/swagger/components/responses/Forbidden.yaml'
+  404:
+    schema:
+      $ref: '/swagger/components/responses/NotFound.yaml'

--- a/server/swagger/public/paths/update_group.yml
+++ b/server/swagger/public/paths/update_group.yml
@@ -1,5 +1,9 @@
-summary: "Post a new group."
-description: "Save a new group."
+summary: "Update properties of a group."
+description: >
+  Update properties of a group. The group must exist in a CO owned by the organisation.
+  For regular groups, only the name, description and auto_provision_members properties can be
+  updated.
+  For service groups, only the the auto_provision_members property can be updated.
 
 tags:
   - "Organisation"

--- a/server/swagger/public/schemas/GroupUpdate.yaml
+++ b/server/swagger/public/schemas/GroupUpdate.yaml
@@ -1,0 +1,16 @@
+---
+type: object
+properties:
+  name:
+    type: string
+    example: "AI researchers"
+    description: "Optional; update the name of the group"
+  description:
+    type: string
+    example: "AI researchers"
+    description: "Optional; update the description of the group"
+  auto_provision_members:
+    type: boolean
+    description: "Optional: if true then make every member member of this group"
+    example: true
+required: []

--- a/server/test/api/test_group.py
+++ b/server/test/api/test_group.py
@@ -154,6 +154,13 @@ class TestGroup(AbstractTest):
 
         self.assertIsNotNone(self.find_group_membership(group_ai_dev_identifier, "urn:jane"))
 
+    def test_add_membership_forbidden_api(self):
+        self.post(f"/api/groups/v1/{group_ai_dev_identifier}",
+                  body={"uid": "urn:jane"},
+                  headers={"Authorization": f"Bearer {unifra_secret}"},
+                  with_basic_auth=False,
+                  response_status_code=403)
+
     def test_add_membership_api_not_collaboration_member_forbidden(self):
         peter = self.find_entity_by_name(User, "Peter Doe")
         self.assertFalse(self.find_entity_by_name(Collaboration, co_ai_computing_name).is_member(peter.id))

--- a/server/test/api/test_group.py
+++ b/server/test/api/test_group.py
@@ -247,6 +247,30 @@ class TestGroup(AbstractTest):
         self.assertEqual(group.description, "a different description")
         self.assertEqual(group.auto_provision_members, True)
 
+    def test_update_group_servicegroup_api(self):
+        group = Group.query.filter(Group.name == service_group_mail_name
+                                   and Group.collaboration.identifier == co_research_uuid).first()
+
+        res = self.put(f"/api/groups/v1/{group.identifier}",
+                       body={
+                           "auto_provision_members": True
+                       },
+                       headers={"Authorization": f"Bearer {unifra_secret}"},
+                       with_basic_auth=False)
+
+        # need to refetch the group because after the API call the group session is no longer bound to the DB session
+        group = Group.query.filter(Group.name == service_group_mail_name
+                                   and Group.collaboration.identifier == co_research_uuid).first()
+
+        self.assertEqual(res["identifier"], group.identifier)
+        self.assertEqual(res["name"], group.name)
+        self.assertEqual(res["short_name"], group.short_name)
+        self.assertEqual(res["description"], group.description)
+        self.assertEqual(res["auto_provision_members"], True)
+
+        self.assertEqual(4, len(group.collaboration_memberships))
+        self.assertEqual(group.auto_provision_members, True)
+
     def test_update_group_not_allowed_api(self):
         self.put(f"/api/groups/v1/{group_science_identifier}",
                  body={
@@ -279,6 +303,7 @@ class TestGroup(AbstractTest):
                  with_basic_auth=False,
                  response_status_code=400)
 
+    def test_update_group_servicegroup_wrong_attribute_api(self):
         group = Group.query.filter(Group.name == service_group_mail_name
                                    and Group.collaboration.identifier == co_research_uuid).first()
 

--- a/server/test/seed.py
+++ b/server/test/seed.py
@@ -72,6 +72,7 @@ group_ai_researchers_short_name = "ai_res"
 group_ai_researchers_identifier = "9734e4c4-d23e-4228-b0e0-8e6a5b85e72e"
 group_ai_dev_identifier = "4c270cff-de30-49e8-a3bc-df032536b37c"
 group_science_name = "Science"
+group_science_identifier = "e46e388c-9362-4aaa-b23f-a855bf559598"
 
 # services
 service_mail_name = "Mail Services"
@@ -636,7 +637,7 @@ def seed(db, app_config, skip_seed=False):
     group_science = Group(name=group_science_name,
                           short_name="science",
                           global_urn="uva:research:science",
-                          identifier="e46e388c-9362-4aaa-b23f-a855bf559598",
+                          identifier=group_science_identifier,
                           auto_provision_members=True,
                           description="Science",
                           collaboration=uva_research,


### PR DESCRIPTION
Add a `/api/groups/v1/{group_identifier}` that allows for updating group properties (name, description, auto_provision_user) from the Org API.