### PR TITLE
Use timezone-aware datetimes everywhere

### DIFF
--- a/server/api/collaboration.py
+++ b/server/api/collaboration.py
@@ -1,7 +1,7 @@
 import base64
 import urllib.request
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from flasgger import swag_from
 from flask import Blueprint, jsonify, request as current_request, current_app, g as request_context
@@ -662,7 +662,7 @@ def _validate_collaboration(data, organisation, new_collaboration=True):
     expiry_date = data.get("expiry_date")
     if expiry_date:
         past_dates_allowed = current_app.app_config.feature.past_dates_allowed
-        dt = datetime.fromtimestamp(int(expiry_date), datetime.timezone.utc) + timedelta(hours=4)
+        dt = datetime.fromtimestamp(int(expiry_date), timezone.utc) + timedelta(hours=4)
         if not past_dates_allowed and dt < dt_now():
             raise APIBadRequest(f"It is not allowed to set the expiry date ({dt}) in the past")
         data["expiry_date"] = datetime(year=dt.year, month=dt.month, day=dt.day, hour=0, minute=0, second=0)

--- a/server/api/collaboration.py
+++ b/server/api/collaboration.py
@@ -427,7 +427,7 @@ def collaboration_invites():
 
     membership_expiry_date = data.get("membership_expiry_date")
     if membership_expiry_date:
-        membership_expiry_date = datetime.fromtimestamp(data.get("membership_expiry_date"))
+        membership_expiry_date = datetime.fromtimestamp(data.get("membership_expiry_date"), tz=timezone.utc)
     for administrator in administrators:
         invitation = Invitation(hash=generate_token(), message=message, invitee_email=administrator,
                                 collaboration=collaboration, user=user, status="open",

--- a/server/api/collaboration.py
+++ b/server/api/collaboration.py
@@ -665,7 +665,7 @@ def _validate_collaboration(data, organisation, new_collaboration=True):
         dt = datetime.fromtimestamp(int(expiry_date), timezone.utc) + timedelta(hours=4)
         if not past_dates_allowed and dt < dt_now():
             raise APIBadRequest(f"It is not allowed to set the expiry date ({dt}) in the past")
-        data["expiry_date"] = datetime(year=dt.year, month=dt.month, day=dt.day, hour=0, minute=0, second=0)
+        data["expiry_date"] = dt.replace(hour=0, minute=0, second=0, microsecond=0)
     else:
         data["expiry_date"] = None
     # Check if the status needs updating

--- a/server/api/collaboration_membership.py
+++ b/server/api/collaboration_membership.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from flask import Blueprint, request as current_request, jsonify
 
@@ -57,7 +57,7 @@ def update_collaboration_membership_expiry_date():
     membership_id = client_data["membership_id"]
     membership_expiry_date = client_data.get("expiry_date")
     if membership_expiry_date:
-        membership_expiry_date = datetime.fromtimestamp(client_data["expiry_date"])
+        membership_expiry_date = datetime.fromtimestamp(client_data["expiry_date"], tz=timezone.utc)
 
     confirm_collaboration_admin(collaboration_id)
 

--- a/server/api/invitation.py
+++ b/server/api/invitation.py
@@ -58,7 +58,7 @@ def do_resend(invitation_id):
 
 
 def parse_date(val, default_date=None):
-    return datetime.datetime.fromtimestamp(val / 1e3) if val and (
+    return datetime.datetime.fromtimestamp(val / 1e3, tz=datetime.timezone.utc) if val and (
             isinstance(val, float) or isinstance(val, int)) else default_date
 
 

--- a/server/api/invitation.py
+++ b/server/api/invitation.py
@@ -20,6 +20,7 @@ from server.db.domain import Invitation, CollaborationMembership, Collaboration,
 from server.db.models import delete
 from server.mail import mail_collaboration_invitation
 from server.scim.events import broadcast_collaboration_changed
+from server.tools import dt_now
 
 CREATED_BY_SYSTEM = "system"
 
@@ -210,7 +211,7 @@ def invitations_accept():
     if invitation.status != "open":
         raise Conflict(f"The invitation has status {invitation.status}")
 
-    if invitation.expiry_date and invitation.expiry_date < datetime.datetime.now():
+    if invitation.expiry_date and invitation.expiry_date < dt_now():
         if invitation.created_by == "system":
             invitation.status = "expired"
             db.session.merge(invitation)

--- a/server/api/invitation.py
+++ b/server/api/invitation.py
@@ -46,7 +46,7 @@ def do_resend(invitation_id):
         .one()
     confirm_collaboration_admin(invitation.collaboration_id)
     invitation.expiry_date = default_expiry_date() if invitation.is_expired() else invitation.expiry_date
-    invitation.created_at = datetime.date.today() if invitation.is_expired() else invitation.created_at
+    invitation.created_at = dt_now() if invitation.is_expired() else invitation.created_at
     db.session.merge(invitation)
     mail_collaboration_invitation({
         "salutation": "Dear",

--- a/server/api/mfa.py
+++ b/server/api/mfa.py
@@ -1,5 +1,4 @@
 import base64
-import datetime
 from io import BytesIO
 
 import pyotp
@@ -18,6 +17,7 @@ from server.db.db import db
 from server.db.domain import User
 from server.logger.context_logger import ctx_logger
 from server.mail import mail_reset_token
+from server.tools import dt_now
 
 mfa_api = Blueprint("mfa_api", __name__, url_prefix="/api/mfa")
 
@@ -50,7 +50,7 @@ def _do_verify_2fa(user: User, secret):
     if totp.verify(totp_value, valid_window=1) or _totp_backdoor(user):
         if not user.second_factor_auth:
             user.second_factor_auth = secret
-        user.last_login_date = datetime.datetime.now()
+        user.last_login_date = dt_now()
         user = db.session.merge(user)
         db.session.commit()
         store_user_in_session(user, True, user.has_agreed_with_aup())

--- a/server/api/mock_user.py
+++ b/server/api/mock_user.py
@@ -1,4 +1,3 @@
-import datetime
 import os
 import uuid
 
@@ -12,6 +11,7 @@ from server.auth.security import is_admin_user, CSRF_TOKEN
 from server.auth.user_claims import add_user_claims
 from server.db.db import db
 from server.db.domain import User
+from server.tools import dt_now
 
 mock_user_api = Blueprint("mock_user_api", __name__, url_prefix="/api/mock")
 
@@ -26,7 +26,7 @@ def login_user():
     sub = data["sub"]  # oidc sub maps to sbs uid - see user_claims
     user = User.query.filter(User.uid == sub).first() or User(created_by="system", updated_by="system",
                                                               external_id=str(uuid.uuid4()))
-    user.last_login_date = datetime.datetime.now()
+    user.last_login_date = dt_now()
     add_user_claims(data, sub, user)
     db.session.merge(user)
 

--- a/server/api/organisation_invitation.py
+++ b/server/api/organisation_invitation.py
@@ -1,5 +1,4 @@
 from server.tools import dt_now
-import datetime
 
 from flask import Blueprint, request as current_request, current_app
 from sqlalchemy.orm import joinedload
@@ -30,7 +29,7 @@ def do_resend(organisation_invitation_id):
         .one()
     confirm_organisation_admin(organisation_invitation.organisation_id)
     organisation_invitation.expiry_date = default_expiry_date()
-    organisation_invitation.created_at = datetime.date.today(),
+    organisation_invitation.created_at = dt_now()
     organisation_invitation = db.session.merge(organisation_invitation)
     mail_organisation_invitation({
         "salutation": "Dear",

--- a/server/api/organisation_invitation.py
+++ b/server/api/organisation_invitation.py
@@ -1,3 +1,4 @@
+from server.tools import dt_now
 import datetime
 
 from flask import Blueprint, request as current_request, current_app
@@ -61,7 +62,7 @@ def organisation_invitations_accept():
         .filter(OrganisationInvitation.hash == current_request.get_json()["hash"]) \
         .one()
 
-    if organisation_invitation.expiry_date and organisation_invitation.expiry_date < datetime.datetime.now():
+    if organisation_invitation.expiry_date and organisation_invitation.expiry_date < dt_now():
         delete(OrganisationInvitation, organisation_invitation.id)
         raise Conflict(f"The invitation has expired at {organisation_invitation.expiry_date}")
 

--- a/server/api/service_invitation.py
+++ b/server/api/service_invitation.py
@@ -1,5 +1,3 @@
-import datetime
-
 from flask import Blueprint, request as current_request, current_app
 from sqlalchemy.orm import joinedload
 from werkzeug.exceptions import Conflict
@@ -30,7 +28,7 @@ def do_resend(service_invitation_id):
         .one()
     confirm_service_admin(service_invitation.service_id)
     service_invitation.expiry_date = default_expiry_date()
-    service_invitation.created_at = datetime.date.today(),
+    service_invitation.created_at = dt_now()
     service_invitation = db.session.merge(service_invitation)
     mail_service_invitation({
         "salutation": "Dear",

--- a/server/api/service_invitation.py
+++ b/server/api/service_invitation.py
@@ -10,6 +10,7 @@ from server.db.defaults import default_expiry_date
 from server.db.domain import ServiceInvitation, Service, ServiceMembership, db
 from server.db.models import delete
 from server.mail import mail_service_invitation
+from server.tools import dt_now
 
 service_invitations_api = Blueprint("service_invitations_api", __name__,
                                     url_prefix="/api/service_invitations")
@@ -60,7 +61,7 @@ def service_invitations_accept():
         .filter(ServiceInvitation.hash == current_request.get_json()["hash"]) \
         .one()
 
-    if service_invitation.expiry_date and service_invitation.expiry_date < datetime.datetime.now():
+    if service_invitation.expiry_date and service_invitation.expiry_date < dt_now():
         delete(ServiceInvitation, service_invitation.id)
         raise Conflict(f"The invitation has expired at {service_invitation.expiry_date}")
 

--- a/server/api/token.py
+++ b/server/api/token.py
@@ -11,6 +11,7 @@ from server.db.defaults import USER_TOKEN_INTROSPECT, SERVICE_TOKEN_INTROSPECTIO
 from server.db.activity import update_last_activity_date
 from server.db.domain import UserToken
 from server.db.models import log_user_login
+from server.tools import dt_now
 
 token_api = Blueprint("token_api", __name__, url_prefix="/api/tokens")
 
@@ -26,7 +27,7 @@ def introspect():
     if not user_token or user_token.service_id != service.id:
         res = {"status": "token-unknown", "active": False}
 
-    current_time = datetime.datetime.utcnow()
+    current_time = dt_now()
     expiry_date = current_time - datetime.timedelta(days=service.token_validity_days)
     if res["active"] and user_token.created_at < expiry_date:
         res = {"status": "token-expired", "active": False}

--- a/server/api/user_saml.py
+++ b/server/api/user_saml.py
@@ -1,5 +1,4 @@
 import uuid
-from datetime import datetime
 from urllib.parse import urlencode
 
 from flask import Blueprint, current_app, request as current_request
@@ -17,7 +16,9 @@ from server.db.defaults import STATUS_ACTIVE, PROXY_AUTHZ, PROXY_AUTHZ_SBS
 from server.db.domain import User, Service
 from server.db.models import log_user_login
 from server.logger.context_logger import ctx_logger
+from server import tools
 import urllib.parse
+
 
 user_saml_api = Blueprint("user_saml_api", __name__, url_prefix="/api/users")
 
@@ -201,7 +202,7 @@ def _do_attributes(user, uid, service, service_entity_id, not_authorized_func, a
         logger.debug(f"Returning interrupt for user {uid} and service_entity_id {service_entity_id} to accept AUP")
         return not_authorized_func(service, AUP_NOT_AGREED)
 
-    now = datetime.now()
+    now = tools.dt_now()
     for coll in connected_collaborations:
         coll.last_activity_date = now
         db.session.merge(coll)

--- a/server/api/user_token.py
+++ b/server/api/user_token.py
@@ -1,5 +1,3 @@
-import datetime
-
 from flask import Blueprint, jsonify, request as current_request, session
 from werkzeug.exceptions import Forbidden
 
@@ -10,6 +8,7 @@ from server.auth.security import current_user_id
 from server.db.db import db
 from server.db.domain import UserToken, User, Service
 from server.db.models import save, delete
+from server.tools import dt_now
 
 user_token_api = Blueprint("user_token_api", __name__, url_prefix="/api/user_tokens")
 
@@ -90,7 +89,7 @@ def update_token():
 def renew_lease():
     data = _sanitize_and_verify(current_request.get_json(), hash_token=False)
     user_token = db.session.get(UserToken, data["id"])
-    user_token.created_at = datetime.datetime.utcnow()
+    user_token.created_at = dt_now()
     db.session.merge(user_token)
     return {}, 201
 

--- a/server/auth/mfa.py
+++ b/server/auth/mfa.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import jwt
 import requests
@@ -11,6 +11,8 @@ from server.auth.security import is_admin_user, CSRF_TOKEN
 from server.db.db import db
 from server.db.domain import Organisation, SchacHomeOrganisation
 from server.logger.context_logger import ctx_logger
+from server.tools import dt_now
+
 
 ACR_VALUES = "https://refeds.org/profile/mfa"
 
@@ -119,7 +121,7 @@ def _idp_configured(identity_providers, action, schac_home=None, entity_id=None)
 def has_valid_mfa(user):
     last_login_date = user.last_login_date
     login_sso_cutoff = timedelta(hours=0, minutes=int(current_app.app_config.mfa_sso_time_in_minutes))
-    valid_mfa_sso = last_login_date and datetime.now() - user.last_login_date < login_sso_cutoff
+    valid_mfa_sso = last_login_date and dt_now() - user.last_login_date < login_sso_cutoff
 
     logger = ctx_logger("user_api")
     logger.debug(f"has_valid_mfa: {valid_mfa_sso} (user={user}, last_login={last_login_date}")

--- a/server/auth/rate_limit.py
+++ b/server/auth/rate_limit.py
@@ -5,6 +5,7 @@ from werkzeug.exceptions import TooManyRequests
 
 from server.db.db import db
 from server.db.domain import User
+from server.tools import dt_now
 
 
 def check_rate_limit(user):
@@ -20,16 +21,16 @@ def rate_limit_reached(user: User):
     redis = current_app.redis_client
     key = str(user.id)
     value = redis.get(key)
-    rate_limit_info = json.loads(value) if value else {"date": datetime.now().isoformat(), "count": 0}
+    rate_limit_info = json.loads(value) if value else {"date": dt_now().isoformat(), "count": 0}
     first_guess = datetime.fromisoformat(rate_limit_info["date"])
-    seconds_ago = datetime.now() - timedelta(hours=0, minutes=0, seconds=30)
+    seconds_ago = dt_now() - timedelta(hours=0, minutes=0, seconds=30)
     count = rate_limit_info["count"]
     rate_limit = current_app.app_config.rate_limit_totp_guesses_per_30_seconds
     max_reached = count >= rate_limit and first_guess >= seconds_ago
     if not max_reached:
         # Need to reset the first_guess if it is more then 30 seconds ago, otherwise the user can still brute force
         in_30_seconds_window = first_guess > seconds_ago
-        new_date = first_guess.isoformat() if in_30_seconds_window else datetime.now().isoformat()
+        new_date = first_guess.isoformat() if in_30_seconds_window else dt_now().isoformat()
         new_count = count + 1 if in_30_seconds_window else 0
         redis.set(key, json.dumps({"date": new_date, "count": new_count}))
     return max_reached

--- a/server/auth/user_claims.py
+++ b/server/auth/user_claims.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import datetime
 import os
 import random
 import re
@@ -15,6 +14,7 @@ from server.db.defaults import STATUS_SUSPENDED
 from server.db.domain import User, UserNameHistory, Collaboration
 from server.logger.context_logger import ctx_logger
 from server.mail import mail_error
+from server.tools import dt_now
 
 claim_attribute_mapping_value = [
     {"sub": "uid"},
@@ -90,7 +90,7 @@ def add_user_claims(user_info_json, uid, user):
 
 # return all active (non-expired/suspended) collaboration from the list
 def _active_collaborations(collaborations: Iterator[Collaboration]) -> Iterator[Collaboration]:
-    now = datetime.datetime.utcnow()
+    now = dt_now()
     for collaboration in collaborations:
         not_expired = not collaboration.expiry_date or collaboration.expiry_date > now
         if not_expired and collaboration.status != STATUS_SUSPENDED:
@@ -142,7 +142,7 @@ def co_tags(connected_collaborations: list[Collaboration]) -> set[str]:
 
 def collaboration_memberships_for_service(user, service):
     memberships = []
-    now = datetime.datetime.utcnow()
+    now = dt_now()
     if user and service:
         for cm in user.collaboration_memberships:
             co_expired = cm.collaboration.expiry_date and cm.collaboration.expiry_date < now

--- a/server/cron/cleanup_non_open_requests.py
+++ b/server/cron/cleanup_non_open_requests.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import selectinload
 from server.cron.shared import obtain_lock
 from server.db.domain import CollaborationRequest, JoinRequest
 from server.db.models import delete
+from server.tools import dt_now
 
 cleanup_non_open_requests_lock_name = "cleanup_non_open_requests_lock_name"
 
@@ -21,7 +22,7 @@ def _do_cleanup_non_open_requests(app):
     with app.app_context():
         cfq = app.app_config.user_requests_retention
 
-        current_time = datetime.datetime.utcnow()
+        current_time = dt_now()
         retention_date = current_time - datetime.timedelta(days=cfq.outstanding_join_request_days_threshold)
 
         start = int(time.time() * 1000.0)

--- a/server/cron/collaboration_expiration.py
+++ b/server/cron/collaboration_expiration.py
@@ -9,6 +9,7 @@ from server.db.db import db
 from server.db.defaults import STATUS_EXPIRED, STATUS_ACTIVE
 from server.db.domain import Collaboration
 from server.mail import mail_collaboration_expires_notification
+from server.tools import dt_now
 
 collaboration_expiration_lock_name = "collaboration_expiration_lock_name"
 
@@ -23,7 +24,7 @@ def _do_expire_collaboration(app):
     with app.app_context():
         cfq = app.app_config.collaboration_expiration
 
-        now = datetime.datetime.utcnow()
+        now = dt_now()
 
         start = int(time.time() * 1000.0)
         logger = logging.getLogger("scheduler")

--- a/server/cron/collaboration_inactivity_suspension.py
+++ b/server/cron/collaboration_inactivity_suspension.py
@@ -9,6 +9,7 @@ from server.db.db import db
 from server.db.defaults import STATUS_ACTIVE, STATUS_SUSPENDED
 from server.db.domain import Collaboration
 from server.mail import mail_collaboration_suspension_notification
+from server.tools import dt_now
 
 collaboration_inactivity_suspension_lock_name = "collaboration_inactivity_suspension_lock_name"
 
@@ -23,7 +24,7 @@ def _do_suspend_collaboration(app):
     with app.app_context():
         cfq = app.app_config.collaboration_suspension
 
-        now = datetime.datetime.utcnow()
+        now = dt_now()
 
         start = int(time.time() * 1000.0)
         logger = logging.getLogger("scheduler")

--- a/server/cron/membership_expiration.py
+++ b/server/cron/membership_expiration.py
@@ -9,6 +9,7 @@ from server.db.db import db
 from server.db.defaults import STATUS_EXPIRED, STATUS_ACTIVE
 from server.db.domain import CollaborationMembership
 from server.mail import mail_membership_expires_notification
+from server.tools import dt_now
 
 membership_expiration_lock_name = "membership_expiration_lock_name"
 
@@ -23,7 +24,7 @@ def _do_expire_memberships(app):
     with app.app_context():
         cfq = app.app_config.membership_expiration
 
-        now = datetime.datetime.utcnow()
+        now = dt_now()
 
         start = int(time.time() * 1000.0)
         logger = logging.getLogger("scheduler")

--- a/server/cron/orphan_users.py
+++ b/server/cron/orphan_users.py
@@ -9,6 +9,7 @@ from server.db.audit_mixin import AuditLog
 from server.db.db import db
 from server.db.domain import User
 from server.mail import mail_membership_orphan_users_deleted
+from server.tools import dt_now
 
 orphan_users_lock_name = "orphan_users_lock_name"
 
@@ -21,7 +22,7 @@ def _do_orphan_users(app):
     with app.app_context():
         cfq = app.app_config.orphan_users
 
-        now = datetime.datetime.utcnow()
+        now = dt_now()
 
         start = int(time.time() * 1000.0)
         logger = logging.getLogger("scheduler")

--- a/server/cron/outstanding_requests.py
+++ b/server/cron/outstanding_requests.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import contains_eager
 from server.cron.shared import obtain_lock
 from server.db.domain import CollaborationRequest, JoinRequest
 from server.mail import mail_outstanding_requests
+from server.tools import dt_now
 
 outstanding_requests_lock_name = "outstanding_requests_lock_name"
 
@@ -21,7 +22,7 @@ def _do_outstanding_requests(app):
     with app.app_context():
         cfq = app.app_config.platform_admin_notifications
 
-        current_time = datetime.datetime.utcnow()
+        current_time = dt_now()
         retention_date = current_time - datetime.timedelta(days=cfq.outstanding_join_request_days_threshold)
 
         start = int(time.time() * 1000.0)

--- a/server/cron/scim_sweep_services.py
+++ b/server/cron/scim_sweep_services.py
@@ -6,6 +6,7 @@ from server.cron.shared import obtain_lock
 from server.db.db import db
 from server.db.domain import Service
 from server.scim.sweep import perform_sweep
+from server.tools import dt_now
 
 scim_sweep_services_lock_name = "scim_sweep_services_lock_name"
 
@@ -25,7 +26,7 @@ def _do_scim_sweep_services(app):
             .filter(Service.sweep_scim_enabled == True) \
             .all()  # noqa: E712
 
-        now = datetime.datetime.utcnow()
+        now = dt_now()
 
         def service_needs_sweeping(service: Service):
             if service.sweep_scim_last_run is None:

--- a/server/db/activity.py
+++ b/server/db/activity.py
@@ -1,10 +1,9 @@
-from datetime import datetime
-
 from server.db.db import db
 from server.db.domain import Collaboration
+from server.tools import dt_now
 
 
 def update_last_activity_date(collaboration_id):
     collaboration = db.session.get(Collaboration, collaboration_id)
-    collaboration.last_activity_date = datetime.now()
+    collaboration.last_activity_date = dt_now()
     db.session.merge(collaboration)

--- a/server/db/audit_mixin.py
+++ b/server/db/audit_mixin.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import declarative_base
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.orm.attributes import get_history
 
-from server.db.db import db
+from server.db.db import db, TZDateTime
 from server.db.json_serialize_base import JsonSerializableBase
 
 ACTION_CREATE = 1
@@ -39,7 +39,7 @@ class AuditLog(JsonSerializableBase, db.Model):
     action = db.Column("action", db.Integer())
     state_before = db.Column("state_before", db.Text())
     state_after = db.Column("state_after", db.Text())
-    created_at = db.Column("created_at", db.DateTime(timezone=True), server_default=db.text("CURRENT_TIMESTAMP"),
+    created_at = db.Column("created_at", TZDateTime(), server_default=db.text("CURRENT_TIMESTAMP"),
                            nullable=False)
 
     def __init__(self, current_user_id, subject_id, target_type, target_id, target_name, parent_id, parent_name, action,

--- a/server/db/audit_mixin.py
+++ b/server/db/audit_mixin.py
@@ -8,7 +8,8 @@ from sqlalchemy.orm import declarative_base
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.orm.attributes import get_history
 
-from server.db.db import db, TZDateTime
+from server.db.datetime import TZDateTime
+from server.db.db import db
 from server.db.json_serialize_base import JsonSerializableBase
 
 ACTION_CREATE = 1

--- a/server/db/datetime.py
+++ b/server/db/datetime.py
@@ -12,14 +12,15 @@ class TZDateTime(sqlalchemy.TypeDecorator):
     def process_bind_param(self, value, dialect):
         if value is None:
             return None
-        elif isinstance(value, datetime.date):
-            # convert to datetime, setting time to 0
-            return datetime.datetime(value.year, value.month, value.day, tzinfo=datetime.timezone.utc)
         elif isinstance(value, datetime.datetime):
             if value.tzinfo is None:
                 raise Exception(f"Datetime '{value}' must be timezone aware")
             else:
                 return value.astimezone(datetime.timezone.utc).replace(tzinfo=None)
+        # note: datetime.date is also an instance of datetime.datetime, so ordering matters here
+        elif isinstance(value, datetime.date):
+            # convert to datetime, setting time to 0
+            return datetime.datetime(value.year, value.month, value.day, tzinfo=datetime.timezone.utc)
         else:
             raise Exception(f"Unknown type '{type(value)}' for datetime")
 

--- a/server/db/datetime.py
+++ b/server/db/datetime.py
@@ -14,7 +14,7 @@ class TZDateTime(sqlalchemy.TypeDecorator):
             return None
         elif isinstance(value, datetime.datetime):
             if value.tzinfo is None:
-                raise Exception(f"Datetime '{value}' must be timezone aware")
+                raise ValueError(f"Datetime '{value}' must be timezone aware")
             else:
                 return value.astimezone(datetime.timezone.utc).replace(tzinfo=None)
         # note: datetime.date is also an instance of datetime.datetime, so ordering matters here
@@ -22,14 +22,12 @@ class TZDateTime(sqlalchemy.TypeDecorator):
             # convert to datetime, setting time to 0
             return datetime.datetime(value.year, value.month, value.day, tzinfo=datetime.timezone.utc)
         else:
-            raise Exception(f"Unknown type '{type(value)}' for datetime")
+            raise TypeError(f"Unknown type '{type(value)}' for datetime")
 
     def process_result_value(self, value, dialect):
         if value is None:
             return None
-        elif value.tzinfo is None:
+
+        if value.tzinfo is None:
             # database returned non-timezoned datetime, so assume UTC
             return value.replace(tzinfo=datetime.timezone.utc)
-        else:
-            # database returned timezone aware datetime, so convert to UTC
-            return value.astimezone(datetime.timezone.utc)

--- a/server/db/datetime.py
+++ b/server/db/datetime.py
@@ -1,15 +1,14 @@
 import datetime
 
-from db import db
+import sqlalchemy
 
 
 # make sure all database columns can be used as timezone aware datetime
 # adapted from https://docs.sqlalchemy.org/en/20/core/custom_types.html#store-timezone-aware-timestamps-as-timezone-naive-utc
-class TZDateTime(db.TypeDecorator):
-    impl = db.DateTime
+class TZDateTime(sqlalchemy.TypeDecorator):
+    impl = sqlalchemy.DateTime
     cache_ok = True
 
-    @staticmethod
     def process_bind_param(self, value, dialect):
         if value is None:
             return None
@@ -24,7 +23,6 @@ class TZDateTime(db.TypeDecorator):
         else:
             raise Exception(f"Unknown type '{type(value)}' for datetime")
 
-    @staticmethod
     def process_result_value(self, value, dialect):
         if value is None:
             return None

--- a/server/db/datetime.py
+++ b/server/db/datetime.py
@@ -1,0 +1,36 @@
+import datetime
+
+from db import db
+
+
+# make sure all database columns can be used as timezone aware datetime
+# adapted from https://docs.sqlalchemy.org/en/20/core/custom_types.html#store-timezone-aware-timestamps-as-timezone-naive-utc
+class TZDateTime(db.TypeDecorator):
+    impl = db.DateTime
+    cache_ok = True
+
+    @staticmethod
+    def process_bind_param(self, value, dialect):
+        if value is None:
+            return None
+        elif isinstance(value, datetime.date):
+            # convert to datetime, setting time to 0
+            return datetime.datetime(value.year, value.month, value.day, tzinfo=datetime.timezone.utc)
+        elif isinstance(value, datetime.datetime):
+            if value.tzinfo is None:
+                raise Exception(f"Datetime '{value}' must be timezone aware")
+            else:
+                return value.astimezone(datetime.timezone.utc).replace(tzinfo=None)
+        else:
+            raise Exception(f"Unknown type '{type(value)}' for datetime")
+
+    @staticmethod
+    def process_result_value(self, value, dialect):
+        if value is None:
+            return None
+        elif value.tzinfo is None:
+            # database returned non-timezoned datetime, so assume UTC
+            return value.replace(tzinfo=datetime.timezone.utc)
+        else:
+            # database returned timezone aware datetime, so convert to UTC
+            return value.astimezone(datetime.timezone.utc)

--- a/server/db/defaults.py
+++ b/server/db/defaults.py
@@ -7,6 +7,8 @@ from typing import Optional
 
 from werkzeug.exceptions import BadRequest
 
+from server.tools import dt_now
+
 full_text_search_autocomplete_limit = 16
 
 STATUS_ACTIVE = "active"
@@ -36,7 +38,7 @@ def default_expiry_date(json_dict=None):
     return datetime.combine(date.today(), time()) + timedelta(days=15)
 
 
-def calculate_expiry_period(invitation, today=datetime.today()):
+def calculate_expiry_period(invitation, today=dt_now()):
     if (isinstance(invitation, Iterable) and "expiry_date" not in invitation) or not invitation.expiry_date:
         return "15 days"
     diff = invitation.expiry_date - today

--- a/server/db/defaults.py
+++ b/server/db/defaults.py
@@ -2,7 +2,7 @@ import random
 import re
 import string
 from collections.abc import Iterable
-from datetime import datetime, date, time, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 from werkzeug.exceptions import BadRequest
@@ -33,9 +33,9 @@ USER_TOKEN_INTROSPECT = "user_token_introspect"
 def default_expiry_date(json_dict=None):
     if json_dict is not None and "expiry_date" in json_dict:
         ms = int(json_dict["expiry_date"])
-        dt = datetime.utcfromtimestamp(ms)
-        return datetime(year=dt.year, month=dt.month, day=dt.day, hour=0, minute=0, second=0)
-    return datetime.combine(date.today(), time()) + timedelta(days=15)
+        dt = datetime.fromtimestamp(ms, timezone.utc)
+        return datetime(year=dt.year, month=dt.month, day=dt.day, hour=0, minute=0, second=0, tzinfo=timezone.utc)
+    return dt_now() + timedelta(days=15)
 
 
 def calculate_expiry_period(invitation, today=dt_now()):

--- a/server/db/domain.py
+++ b/server/db/domain.py
@@ -1,4 +1,3 @@
-import datetime
 from uuid import uuid4
 
 from flask import current_app
@@ -6,11 +5,12 @@ from sqlalchemy import select, func
 from sqlalchemy.orm import column_property
 
 from server.db.audit_mixin import Base, metadata
+from server.db.datetime import TZDateTime
 from server.db.db import db
 from server.db.defaults import STATUS_ACTIVE
 from server.db.logo_mixin import LogoMixin
 from server.db.secret_mixin import SecretMixin
-from server.db.datetime import TZDateTime
+from server.tools import dt_now
 
 
 def gen_uuid4():
@@ -198,10 +198,10 @@ class CollaborationMembership(Base, db.Model):
                            nullable=False)
 
     def is_expired(self):
-        return self.expiry_date and datetime.datetime.now(datetime.timezone.utc) > self.expiry_date
+        return self.expiry_date and dt_now() > self.expiry_date
 
     def is_active(self):
-        now = datetime.datetime.now(datetime.timezone.utc)
+        now = dt_now()
         not_expired = not self.expiry_date or self.expiry_date > now
         co_not_expired = not self.collaboration.expiry_date or self.collaboration.expiry_date > now
         return not_expired and co_not_expired and not self.user.suspended
@@ -261,7 +261,7 @@ class Invitation(Base, db.Model):
             raise ValueError(f"{role} is not valid. Valid roles are admin and member")
 
     def is_expired(self):
-        return self.expiry_date and datetime.datetime.now(datetime.timezone.utc) > self.expiry_date
+        return self.expiry_date and dt_now() > self.expiry_date
 
 
 services_collaborations_association = db.Table(

--- a/server/db/domain.py
+++ b/server/db/domain.py
@@ -198,10 +198,10 @@ class CollaborationMembership(Base, db.Model):
                            nullable=False)
 
     def is_expired(self):
-        return self.expiry_date and datetime.datetime.now(datetime.UTC) > self.expiry_date
+        return self.expiry_date and datetime.datetime.now(datetime.timezone.utc) > self.expiry_date
 
     def is_active(self):
-        now = datetime.datetime.now(datetime.UTC)
+        now = datetime.datetime.now(datetime.timezone.utc)
         not_expired = not self.expiry_date or self.expiry_date > now
         co_not_expired = not self.collaboration.expiry_date or self.collaboration.expiry_date > now
         return not_expired and co_not_expired and not self.user.suspended
@@ -261,7 +261,7 @@ class Invitation(Base, db.Model):
             raise ValueError(f"{role} is not valid. Valid roles are admin and member")
 
     def is_expired(self):
-        return self.expiry_date and datetime.datetime.now(datetime.UTC) > self.expiry_date
+        return self.expiry_date and datetime.datetime.now(datetime.timezone.utc) > self.expiry_date
 
 
 services_collaborations_association = db.Table(

--- a/server/db/models.py
+++ b/server/db/models.py
@@ -132,7 +132,7 @@ def parse_date_fields(json_dict):
         if date_field in json_dict:
             val = json_dict[date_field]
             if isinstance(val, float) or isinstance(val, int):
-                json_dict[date_field] = datetime.datetime.fromtimestamp(val / 1e3)
+                json_dict[date_field] = datetime.datetime.fromtimestamp(val / 1e3, tz=datetime.timezone.utc)
         for rel in flatten(filter(lambda i: isinstance(i, list), json_dict.values())):
             parse_date_fields(rel)
 

--- a/server/mail.py
+++ b/server/mail.py
@@ -13,8 +13,6 @@ from server.db.db import db
 from server.db.defaults import calculate_expiry_period
 from server.db.domain import User, UserMail
 from server.logger.context_logger import ctx_logger
-from server.tools import dt_now
-
 from server.mail_types.mail_types import COLLABORATION_REQUEST_MAIL, \
     COLLABORATION_JOIN_REQUEST_MAIL, AUTOMATIC_COLLABORATION_JOIN_REQUEST_MAIL, ORGANISATION_INVITATION_MAIL, \
     COLLABORATION_INVITATION_MAIL, ACCEPTED_JOIN_REQUEST_MAIL, DENIED_JOIN_REQUEST_MAIL, \
@@ -24,6 +22,7 @@ from server.mail_types.mail_types import COLLABORATION_REQUEST_MAIL, \
     COLLABORATION_EXPIRED_NOTIFICATION_MAIL, COLLABORATION_SUSPENDED_NOTIFICATION_MAIL, \
     COLLABORATION_SUSPENSION_WARNING_MAIL, MEMBERSHIP_EXPIRED_NOTIFICATION_MAIL, MEMBERSHIP_EXPIRES_WARNING_MAIL, \
     SERVICE_INVITATION_MAIL, ACCEPTED_SERVICE_REQUEST_MAIL, DENIED_SERVICE_REQUEST_MAIL
+from server.tools import dt_now
 
 
 def _send_async_email(ctx, msg, mail):
@@ -72,7 +71,7 @@ def _user_attributes(user: User):
 
 
 def _now_strf_time():
-    return datetime.datetime.now().strftime('%Y-%m-%d %H:%M')
+    return dt_now().strftime('%Y-%m-%d %H:%M')
 
 
 def _do_send_mail(subject, recipients, template, context, preview, working_outside_of_request_context=False, cc=None,

--- a/server/mail.py
+++ b/server/mail.py
@@ -13,6 +13,8 @@ from server.db.db import db
 from server.db.defaults import calculate_expiry_period
 from server.db.domain import User, UserMail
 from server.logger.context_logger import ctx_logger
+from server.tools import dt_now
+
 from server.mail_types.mail_types import COLLABORATION_REQUEST_MAIL, \
     COLLABORATION_JOIN_REQUEST_MAIL, AUTOMATIC_COLLABORATION_JOIN_REQUEST_MAIL, ORGANISATION_INVITATION_MAIL, \
     COLLABORATION_INVITATION_MAIL, ACCEPTED_JOIN_REQUEST_MAIL, DENIED_JOIN_REQUEST_MAIL, \
@@ -489,7 +491,7 @@ def mail_collaboration_suspension_notification(collaboration, is_warning):
         subject = f"Collaboration {collaboration.name} will be suspended in {threshold} days"
     else:
         subject = f"Collaboration {collaboration.name} has been suspended"
-    now = datetime.datetime.utcnow()
+    now = dt_now()
     suspension_date = format_date_time(now + datetime.timedelta(days=cfq.inactivity_warning_mail_days_threshold))
     _do_send_mail(
         subject=subject,

--- a/server/test/abstract_test.py
+++ b/server/test/abstract_test.py
@@ -26,6 +26,7 @@ from server.db.domain import Collaboration, User, Service, ServiceAup, UserToken
     PamSSOSession, Group, CollaborationMembership
 from server.test.seed import seed, user_sarah_name
 from server.tools import read_file
+from server.tools import dt_now
 
 # See api_users in config/test_config.yml
 BASIC_AUTH_HEADER = {"Authorization": f"Basic {b64encode(b'sysadmin:secret').decode('ascii')}"}
@@ -97,7 +98,7 @@ class AbstractTest(TestCase):
     @staticmethod
     def expire_collaborations(user_name):
         def do_change(collaboration):
-            collaboration.expiry_date = datetime.datetime.utcnow() - datetime.timedelta(days=50)
+            collaboration.expiry_date = dt_now() - datetime.timedelta(days=50)
 
         return AbstractTest.change_collaboration(user_name, do_change)
 
@@ -175,7 +176,7 @@ class AbstractTest(TestCase):
         self.expire_collaboration_memberships(user.collaboration_memberships)
 
     def expire_collaboration_memberships(self, collaboration_memberships):
-        past = datetime.datetime.now() - datetime.timedelta(days=5)
+        past = dt_now() - datetime.timedelta(days=5)
         for cm in collaboration_memberships:
             cm.expiry_date = past
             cm.status = STATUS_EXPIRED
@@ -200,14 +201,14 @@ class AbstractTest(TestCase):
     @staticmethod
     def expire_user_token(raw_token):
         user_token = UserToken.query.filter(UserToken.hashed_token == secure_hash(raw_token)).first()
-        user_token.created_at = datetime.datetime.utcnow() - datetime.timedelta(days=500)
+        user_token.created_at = dt_now() - datetime.timedelta(days=500)
         db.session.merge(user_token)
         db.session.commit()
 
     @staticmethod
     def expire_invitation(hash):
         invitation = Invitation.query.filter(Invitation.hash == hash).first()
-        invitation.expiry_date = datetime.datetime.utcnow() - datetime.timedelta(days=500)
+        invitation.expiry_date = dt_now() - datetime.timedelta(days=500)
         invitation.created_by = "not_system"
         db.session.merge(invitation)
         db.session.commit()
@@ -215,7 +216,7 @@ class AbstractTest(TestCase):
     @staticmethod
     def login_user_2fa(user_uid):
         user = User.query.filter(User.uid == user_uid).one()
-        user.last_login_date = datetime.datetime.now()
+        user.last_login_date = dt_now()
         return AbstractTest._merge_user(user)
 
     @staticmethod
@@ -260,7 +261,7 @@ class AbstractTest(TestCase):
     @staticmethod
     def expire_pam_session(session_id):
         pam_websso = PamSSOSession.query.filter(PamSSOSession.session_id == session_id).first()
-        pam_websso.created_at = datetime.datetime.utcnow() - datetime.timedelta(days=500)
+        pam_websso.created_at = dt_now() - datetime.timedelta(days=500)
         db.session.merge(pam_websso)
         db.session.commit()
 

--- a/server/test/api/test_audit_log.py
+++ b/server/test/api/test_audit_log.py
@@ -1,9 +1,9 @@
-from datetime import datetime
-
 from flask import jsonify
 
 from server.db.audit_mixin import ACTION_DELETE, ACTION_CREATE, ACTION_UPDATE, AuditLog
 from server.db.domain import User, Collaboration, Service, Organisation, Group
+from server.tools import dt_now
+
 from server.test.abstract_test import AbstractTest
 from server.test.seed import service_cloud_name, co_ai_computing_name, \
     service_mail_name, invitation_hash_curious, unihard_invitation_hash, unihard_name, group_science_name, \
@@ -140,7 +140,7 @@ class TestAuditLog(AbstractTest):
 
     def test_no_last_activity_date_only_audit_logs(self):
         collaboration = self.find_entity_by_name(Collaboration, co_ai_computing_name)
-        collaboration.last_activity_date = datetime.now()
+        collaboration.last_activity_date = dt_now()
         self.save_entity(collaboration)
         audit_logs = AuditLog.query.all()
         self.assertEqual(0, len(audit_logs))

--- a/server/test/api/test_collaboration.py
+++ b/server/test/api/test_collaboration.py
@@ -895,7 +895,7 @@ class TestCollaboration(AbstractTest):
         self.put("/api/collaborations/unsuspend", body={"collaboration_id": coll.id})
         coll = self.find_entity_by_name(Collaboration, co_ai_computing_name)
         self.assertEqual(STATUS_ACTIVE, coll.status)
-        self.assertTrue(coll.last_activity_date > dt_now() - datetime.timedelta(hours=1))
+        self.assertGreater(coll.last_activity_date, dt_now() - datetime.timedelta(hours=1))
 
     def test_activate(self):
         coll = self.find_entity_by_name(Collaboration, co_ai_computing_name)
@@ -908,7 +908,7 @@ class TestCollaboration(AbstractTest):
         coll = self.find_entity_by_name(Collaboration, co_ai_computing_name)
         self.assertEqual(STATUS_ACTIVE, coll.status)
         self.assertIsNone(coll.expiry_date)
-        self.assertTrue(coll.last_activity_date > dt_now() - datetime.timedelta(hours=1))
+        self.assertGreater(coll.last_activity_date, dt_now() - datetime.timedelta(hours=1))
 
     def test_id_by_identifier(self):
         res = self.get("/api/collaborations/id_by_identifier",

--- a/server/test/api/test_collaboration.py
+++ b/server/test/api/test_collaboration.py
@@ -11,6 +11,8 @@ from server.db.defaults import STATUS_ACTIVE, STATUS_EXPIRED, STATUS_SUSPENDED
 from server.db.domain import Collaboration, Organisation, Invitation, CollaborationMembership, User, Group, \
     ServiceGroup, Tag, Service
 from server.db.models import flatten
+from server.tools import dt_now
+
 from server.test.abstract_test import AbstractTest, API_AUTH_HEADER
 from server.test.seed import (co_ai_computing_uuid, co_ai_computing_name, co_research_name, user_john_name,
                               co_ai_computing_short_name, co_teachers_name, read_image, co_research_uuid,
@@ -595,7 +597,7 @@ class TestCollaboration(AbstractTest):
         self.assertIsNone(collaboration.accepted_user_policy)
         self.assertIsNotNone(collaboration.logo)
         self.assertEqual(2, len(collaboration.tags))
-        one_day_ago = datetime.datetime.now() - datetime.timedelta(days=1)
+        one_day_ago = dt_now() - datetime.timedelta(days=1)
         self.assertTrue(collaboration.last_activity_date > one_day_ago)
 
         count = Invitation.query.filter(Invitation.collaboration_id == collaboration.id).count()
@@ -885,7 +887,7 @@ class TestCollaboration(AbstractTest):
 
     def test_unsuspend(self):
         coll = self.find_entity_by_name(Collaboration, co_ai_computing_name)
-        coll.last_activity_date = datetime.datetime.now() - datetime.timedelta(days=365)
+        coll.last_activity_date = dt_now() - datetime.timedelta(days=365)
         coll.status = STATUS_SUSPENDED
         db.session.merge(coll)
         db.session.commit()
@@ -893,11 +895,11 @@ class TestCollaboration(AbstractTest):
         self.put("/api/collaborations/unsuspend", body={"collaboration_id": coll.id})
         coll = self.find_entity_by_name(Collaboration, co_ai_computing_name)
         self.assertEqual(STATUS_ACTIVE, coll.status)
-        self.assertTrue(coll.last_activity_date > datetime.datetime.now() - datetime.timedelta(hours=1))
+        self.assertTrue(coll.last_activity_date > dt_now() - datetime.timedelta(hours=1))
 
     def test_activate(self):
         coll = self.find_entity_by_name(Collaboration, co_ai_computing_name)
-        coll.expiry_date = datetime.datetime.now() - datetime.timedelta(days=365)
+        coll.expiry_date = dt_now() - datetime.timedelta(days=365)
         coll.status = STATUS_EXPIRED
         db.session.merge(coll)
         db.session.commit()
@@ -906,7 +908,7 @@ class TestCollaboration(AbstractTest):
         coll = self.find_entity_by_name(Collaboration, co_ai_computing_name)
         self.assertEqual(STATUS_ACTIVE, coll.status)
         self.assertIsNone(coll.expiry_date)
-        self.assertTrue(coll.last_activity_date > datetime.datetime.now() - datetime.timedelta(hours=1))
+        self.assertTrue(coll.last_activity_date > dt_now() - datetime.timedelta(hours=1))
 
     def test_id_by_identifier(self):
         res = self.get("/api/collaborations/id_by_identifier",

--- a/server/test/api/test_dynamic_extended_json_encoder.py
+++ b/server/test/api/test_dynamic_extended_json_encoder.py
@@ -1,17 +1,17 @@
 import time
 import uuid
-from datetime import date
 
 from flask import jsonify
 
 from server.test.abstract_test import AbstractTest
+from server.tools import dt_today
 
 
 class TestDynamicExtendedJSONEncoder(AbstractTest):
 
     def test_encoding(self):
         _uuid = uuid.uuid4()
-        today = date.today()
+        today = dt_today()
 
         obj = {"1": _uuid, "2": today, "3": "default", "4": (1, 2)}
         res = jsonify(obj).json

--- a/server/test/api/test_invitation.py
+++ b/server/test/api/test_invitation.py
@@ -10,6 +10,7 @@ from server.test.abstract_test import AbstractTest
 from server.test.seed import invitation_hash_no_way, co_ai_computing_name, invitation_hash_curious, invitation_hash_uva, \
     co_research_name, unihard_secret, unihard_name, co_ai_computing_short_name, co_ai_computing_join_request_peter_hash, \
     co_ai_computing_uuid, group_ai_researchers_short_name, group_ai_dev_identifier
+from server.tools import dt_now
 
 
 class TestInvitation(AbstractTest):
@@ -48,7 +49,7 @@ class TestInvitation(AbstractTest):
 
     def test_external_collaboration_expired_invitation(self):
         invitation = self._get_invitation_curious()
-        invitation.expiry_date = datetime.datetime.utcnow() - datetime.timedelta(days=500)
+        invitation.expiry_date = dt_now() - datetime.timedelta(days=500)
         invitation.external_identifier = str(uuid.uuid4())
         db.session.merge(invitation)
         db.session.commit()
@@ -217,7 +218,7 @@ class TestInvitation(AbstractTest):
 
     def test_collaboration_external_identifier(self):
         invitation = self._get_invitation_curious()
-        invitation.expiry_date = datetime.datetime.utcnow() - datetime.timedelta(days=500)
+        invitation.expiry_date = dt_now() - datetime.timedelta(days=500)
         invitation.external_identifier = str(uuid.uuid4())
         db.session.merge(invitation)
         db.session.commit()

--- a/server/test/api/test_pam_websso.py
+++ b/server/test/api/test_pam_websso.py
@@ -107,7 +107,7 @@ class TestPamWebSSO(AbstractTest):
                         with_basic_auth=False,
                         headers={"Authorization": f"bearer {service_storage_token}"})
 
-        self.assertEqual(res["cached"], True)
+        self.assertTrue(res["cached"])
 
     def test_check_pin_fail(self):
         with requests.Session():

--- a/server/test/api/test_pam_websso.py
+++ b/server/test/api/test_pam_websso.py
@@ -1,9 +1,11 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import requests
 
 from server.db.db import db
 from server.db.domain import PamSSOSession, User, Service
+from server.tools import dt_now
+
 from server.test.abstract_test import AbstractTest
 from server.test.seed import pam_session_id, service_storage_name, service_storage_token, \
     pam_invalid_service_session_id, user_roger_name
@@ -94,7 +96,7 @@ class TestPamWebSSO(AbstractTest):
     def test_start_cached_login(self):
         self.login_user_2fa("urn:roger")
         roger = self.find_entity_by_name(User, user_roger_name)
-        roger.pam_last_login_date = datetime.now()
+        roger.pam_last_login_date = dt_now()
         db.session.merge(roger)
         db.session.commit()
 
@@ -169,7 +171,7 @@ class TestPamWebSSO(AbstractTest):
     def test_check_pin_time_out(self):
         self.login("urn:peter")
         pam_sso_session = PamSSOSession.query.filter(PamSSOSession.session_id == pam_session_id).one()
-        pam_sso_session.created_at = datetime.utcnow() - timedelta(days=500)
+        pam_sso_session.created_at = dt_now() - timedelta(days=500)
         db.session.merge(pam_sso_session)
         db.session.commit()
 

--- a/server/test/api/test_user.py
+++ b/server/test/api/test_user.py
@@ -10,10 +10,11 @@ from werkzeug.exceptions import BadRequest
 from server.auth.security import CSRF_TOKEN
 from server.db.db import db
 from server.db.domain import Organisation, Collaboration, User, Aup
+from server.tools import dt_now, read_file
+
 from server.test.abstract_test import AbstractTest
 from server.test.seed import (unihard_name, co_ai_computing_name, user_roger_name, user_john_name, user_james_name,
                               co_research_name, co_ai_computing_uuid, user_sarah_name)
-from server.tools import read_file
 
 
 class TestUser(AbstractTest):
@@ -103,7 +104,7 @@ class TestUser(AbstractTest):
         user = User.query.filter(User.name == "user_deletion_warning").one()
         self.assertEqual(False, user.suspended)
         retention = current_app.app_config.retention
-        retention_date = datetime.datetime.now() - datetime.timedelta(days=retention.allowed_inactive_period_days + 1)
+        retention_date = dt_now() - datetime.timedelta(days=retention.allowed_inactive_period_days + 1)
         self.assertTrue(user.last_login_date > retention_date)
 
     def test_search(self):
@@ -338,7 +339,7 @@ class TestUser(AbstractTest):
     def test_update_date_bug(self):
         roger = self.find_entity_by_name(User, user_roger_name)
         roger_id = roger.id
-        now = datetime.datetime.now()
+        now = dt_now()
         roger.last_login_date = now
         roger.last_accessed_date = now
 

--- a/server/test/api/test_user_saml.py
+++ b/server/test/api/test_user_saml.py
@@ -110,7 +110,7 @@ class TestUserSaml(AbstractTest):
 
         network_service = Service.query.filter(Service.entity_id == service_network_entity_id).one()
         parameters = urlencode({"service_id": network_service.uuid4, "service_name": network_service.name})
-        self.assertEqual(res["status"]["redirect_url"], f"{self.app.app_config.base_url}/service-aup?{parameters}")
+        self.assertEqual(f"{self.app.app_config.base_url}/service-aup?{parameters}", res["status"]["redirect_url"], )
 
     def test_proxy_authz_no_user(self):
         res = self.post("/api/users/proxy_authz", body={"user_id": "urn:nope", "service_id": service_mail_entity_id,
@@ -184,7 +184,7 @@ class TestUserSaml(AbstractTest):
                               "homeorganization": "example.com",
                               "user_email": "sarah@ex.com", "user_name": "sarah p"})
         status_ = res["status"]
-        self.assertEqual(status_["result"], "authorized")
+        self.assertEqual("authorized", status_["result"])
 
         sarah = self.find_entity_by_name(User, user_sarah_name)
         self.assertFalse(sarah.ssid_required)
@@ -215,7 +215,7 @@ class TestUserSaml(AbstractTest):
                               "homeorganization": "ssid.org",
                               "user_email": "sarah@ex.com", "user_name": "sarah p"})
         sarah = self.find_entity_by_name(User, user_sarah_name)
-        self.assertEqual(res["status"]["result"], "authorized")
+        self.assertEqual("authorized", res["status"]["result"])
         self.assertFalse(sarah.ssid_required)
 
     def test_proxy_authz_mfa_sbs_idp(self):
@@ -256,7 +256,7 @@ class TestUserSaml(AbstractTest):
                               "homeorganization": "example.com",
                               "user_email": "sarah@ex.com", "user_name": "sarah p"})
         sarah = self.find_entity_by_name(User, user_sarah_name)
-        self.assertEqual(res["status"]["result"], "authorized")
+        self.assertEqual("authorized", res["status"]["result"], )
         self.assertFalse(sarah.ssid_required)
 
     def test_proxy_authz_mfa_service_ssid(self):
@@ -291,7 +291,7 @@ class TestUserSaml(AbstractTest):
                               "homeorganization": "ssid.org"})
         sarah = self.find_entity_by_name(User, user_sarah_name)
 
-        self.assertEqual(res["status"]["result"], "authorized")
+        self.assertEqual("authorized", res["status"]["result"])
         self.assertFalse(sarah.ssid_required)
 
     def test_proxy_authz_mfa_service_idp(self):

--- a/server/test/api/test_user_token.py
+++ b/server/test/api/test_user_token.py
@@ -5,6 +5,7 @@ from server.db.domain import Service, User, UserToken
 from server.test.abstract_test import AbstractTest
 from server.test.seed import (user_sarah_name, service_wiki_name, service_mail_name, service_cloud_name,
                               user_sarah_user_token_network, user_john_name, service_network_name)
+from server.tools import dt_now
 
 
 class TestUserToken(AbstractTest):
@@ -130,6 +131,6 @@ class TestUserToken(AbstractTest):
 
         user_tokens_updated = self.get("/api/user_tokens")
         created_at = int(user_tokens_updated[0]["created_at"])
-        one_day_ago = int((datetime.datetime.utcnow() - datetime.timedelta(days=1)).timestamp())
+        one_day_ago = int((dt_now() - datetime.timedelta(days=1)).timestamp())
         self.assertTrue(created_at > one_day_ago)
         self.assertIsNone(user_tokens[0].get("hashed_token"))

--- a/server/test/cron/test_collaboration_expiration.py
+++ b/server/test/cron/test_collaboration_expiration.py
@@ -7,12 +7,13 @@ from server.db.defaults import STATUS_EXPIRED
 from server.db.domain import Collaboration
 from server.test.abstract_test import AbstractTest
 from server.test.seed import co_ai_computing_name, co_research_name, co_teachers_name
+from server.tools import dt_now
 
 
 class TestCollaborationExpiration(AbstractTest):
 
     def _setup_data(self):
-        now = datetime.datetime.utcnow()
+        now = dt_now()
         cfq = self.app.app_config.collaboration_expiration
         # Will cause expiration warning mail
         threshold_upper = datetime.timedelta(days=cfq.expired_warning_mail_days_threshold)

--- a/server/test/cron/test_collaboration_inactivity_suspension.py
+++ b/server/test/cron/test_collaboration_inactivity_suspension.py
@@ -7,12 +7,13 @@ from server.db.defaults import STATUS_SUSPENDED
 from server.db.domain import Collaboration
 from server.test.abstract_test import AbstractTest
 from server.test.seed import co_ai_computing_name, co_research_name, co_teachers_name
+from server.tools import dt_now
 
 
 class TestCollaborationInactivitySuspension(AbstractTest):
 
     def _setup_data(self):
-        now = datetime.datetime.utcnow()
+        now = dt_now()
         cfq = self.app.app_config.collaboration_suspension
         threshold_for_warning = cfq.collaboration_inactivity_days_threshold - cfq.inactivity_warning_mail_days_threshold
         threshold_upper = datetime.timedelta(days=threshold_for_warning)

--- a/server/test/cron/test_membership_expiration.py
+++ b/server/test/cron/test_membership_expiration.py
@@ -8,12 +8,13 @@ from server.db.domain import Collaboration, CollaborationMembership, User
 from server.test.abstract_test import AbstractTest
 from server.test.seed import co_ai_computing_name, user_sarah_name, user_jane_name, \
     user_boss_name
+from server.tools import dt_now
 
 
 class TestMembershipExpiration(AbstractTest):
 
     def _setup_data(self):
-        now = datetime.datetime.utcnow()
+        now = dt_now()
         cfq = self.app.app_config.membership_expiration
         # Will cause expiration warning mail
         threshold_upper = datetime.timedelta(days=cfq.expired_warning_mail_days_threshold)

--- a/server/test/cron/test_user_suspending.py
+++ b/server/test/cron/test_user_suspending.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from freezegun import freeze_time
 from sqlalchemy import text
@@ -7,6 +7,7 @@ from sqlalchemy.orm import sessionmaker
 from server.cron.user_suspending import suspend_users, suspend_users_lock_name
 from server.db.domain import User, UserNameHistory
 from server.test.abstract_test import AbstractTest
+from server.tools import dt_now
 
 
 class TestUserSuspending(AbstractTest):
@@ -72,11 +73,9 @@ class TestUserSuspending(AbstractTest):
 
         # now fast-forward time
         retention = self.app.app_config.retention
-        newdate = (
-            datetime.utcnow()
-            + timedelta(retention.reminder_suspend_period_days)
-            + timedelta(retention.remove_suspended_users_period_days)
-        )
+        newdate = (dt_now()
+                   + timedelta(retention.reminder_suspend_period_days)
+                   + timedelta(retention.remove_suspended_users_period_days))
         with freeze_time(newdate):
             with mail.record_messages() as outbox:
                 results = suspend_users(self.app)

--- a/server/test/db/test_datetime.py
+++ b/server/test/db/test_datetime.py
@@ -39,6 +39,17 @@ class TestDatetime(AbstractTest):
         test_user_readback = User.query.filter_by(uid=base_user["uid"]).first()
         self.assertEqual(dt, test_user_readback.last_login_date)
 
+    def test_datetime_other_tz(self):
+        dt = datetime.datetime(2019, 1, 1, 0, 0, 0, tzinfo=datetime.timezone(datetime.timedelta(hours=1)))
+        test_user = User(**base_user, last_login_date=dt)
+        db.session.add(test_user)
+        db.session.commit()
+
+        test_user_readback = User.query.filter_by(uid=base_user["uid"]).first()
+        # new tz should be UTC, but actual times should be equal
+        self.assertEqual(datetime.UTC, test_user_readback.last_login_date.tzinfo)
+        self.assertEqual(dt, test_user_readback.last_login_date)
+
     def test_datetime_no_timezone(self):
         invalid_dt = datetime.datetime(2019, 1, 1, 0, 0, 0)
         test_user = User(**base_user, last_login_date=invalid_dt)

--- a/server/test/db/test_datetime.py
+++ b/server/test/db/test_datetime.py
@@ -1,0 +1,55 @@
+import datetime
+
+import pytest
+from sqlalchemy.exc import StatementError
+
+from server.db.db import db
+from server.db.domain import User
+from server.test.abstract_test import AbstractTest
+
+base_user = dict(
+    uid="urn:test",
+    name="Test User",
+    email="test@foo",
+    schac_home_organisation="test.foo",
+    username="test",
+    external_id="test",
+    created_by="testcase",
+    updated_by="testcase"
+)
+
+
+class TestDatetime(AbstractTest):
+
+    def test_datetime_none(self):
+        test_user = User(**base_user, last_login_date=None)
+        db.session.add(test_user)
+        db.session.commit()
+
+        test_user_readback = User.query.filter_by(uid=base_user["uid"]).first()
+        self.assertIsNone(test_user_readback.last_login_date)
+
+    def test_datetime_date(self):
+        dt = datetime.datetime(2019, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
+        date = dt.date()
+        test_user = User(**base_user, last_login_date=date)
+        db.session.add(test_user)
+        db.session.commit()
+
+        test_user_readback = User.query.filter_by(uid=base_user["uid"]).first()
+        self.assertEqual(dt, test_user_readback.last_login_date)
+
+    def test_datetime_no_timezone(self):
+        invalid_dt = datetime.datetime(2019, 1, 1, 0, 0, 0)
+        test_user = User(**base_user, last_login_date=invalid_dt)
+        with pytest.raises(StatementError) as excinfo:
+            db.session.add(test_user)
+            db.session.commit()
+        self.assertIn("must be timezone aware", str(excinfo.value))
+
+    def test_datetime_invalid(self):
+        test_user = User(**base_user, last_login_date=42)
+        with pytest.raises(StatementError) as excinfo:
+            db.session.add(test_user)
+            db.session.commit()
+        self.assertIn("Unknown type '<class 'int'>' for datetime", str(excinfo.value))

--- a/server/test/db/test_datetime.py
+++ b/server/test/db/test_datetime.py
@@ -1,6 +1,5 @@
 import datetime
 
-import pytest
 from sqlalchemy.exc import StatementError
 
 from server.db.db import db
@@ -47,20 +46,20 @@ class TestDatetime(AbstractTest):
 
         test_user_readback = User.query.filter_by(uid=base_user["uid"]).first()
         # new tz should be UTC, but actual times should be equal
-        self.assertEqual(datetime.UTC, test_user_readback.last_login_date.tzinfo)
+        self.assertEqual(datetime.timezone.utc, test_user_readback.last_login_date.tzinfo)
         self.assertEqual(dt, test_user_readback.last_login_date)
 
     def test_datetime_no_timezone(self):
         invalid_dt = datetime.datetime(2019, 1, 1, 0, 0, 0)
         test_user = User(**base_user, last_login_date=invalid_dt)
-        with pytest.raises(StatementError) as excinfo:
+        with self.assertRaises(StatementError) as exc:
             db.session.add(test_user)
             db.session.commit()
-        self.assertIn("must be timezone aware", str(excinfo.value))
+        self.assertIn("must be timezone aware", str(exc.exception))
 
     def test_datetime_invalid(self):
         test_user = User(**base_user, last_login_date=42)
-        with pytest.raises(StatementError) as excinfo:
+        with self.assertRaises(StatementError) as exc:
             db.session.add(test_user)
             db.session.commit()
-        self.assertIn("Unknown type '<class 'int'>' for datetime", str(excinfo.value))
+        self.assertIn("Unknown type '<class 'int'>' for datetime", str(exc.exception))

--- a/server/test/db/test_defaults.py
+++ b/server/test/db/test_defaults.py
@@ -8,32 +8,33 @@ from werkzeug.exceptions import BadRequest
 from server.db.defaults import default_expiry_date, calculate_expiry_period, cleanse_short_name, valid_uri_attributes, \
     uri_re
 from server.db.domain import Invitation
+from server.tools import dt_now
 
 
 class TestDefaults(TestCase):
 
     def test_default_expiry_date(self):
         default_date = default_expiry_date()
-        res = default_date - datetime.datetime.today()
+        res = default_date - dt_now()
         self.assertEqual(14, res.days)
 
     def test_expiry_date(self):
         date = default_expiry_date({"expiry_date": time.time()})
-        res = date - datetime.datetime.today()
+        res = date - dt_now()
         self.assertEqual(-1, res.days)
 
     def test_calculate_expiry_period_days(self):
         period = calculate_expiry_period(
-            munchify({"expiry_date": datetime.datetime.today() + datetime.timedelta(days=15)}))
+            munchify({"expiry_date": dt_now() + datetime.timedelta(days=15)}))
         self.assertTrue(period.endswith("days"))
 
     def test_calculate_expiry_period_hours(self):
-        today = datetime.datetime.today()
+        today = dt_now()
         period = calculate_expiry_period(munchify({"expiry_date": today + datetime.timedelta(hours=6)}), today=today)
         self.assertTrue(period.endswith("hours"))
 
     def test_calculate_expiry_period_today(self):
-        today = datetime.datetime.today()
+        today = dt_now()
         period = calculate_expiry_period(munchify({"expiry_date": today}), today=today)
         self.assertEqual("0 minutes", period)
 
@@ -45,23 +46,23 @@ class TestDefaults(TestCase):
         self.assertEqual("15 days", period)
 
     def test_calculate_expiry_period_diff(self):
-        today = datetime.datetime.today()
+        today = dt_now()
         period = calculate_expiry_period(munchify({"expiry_date": today + datetime.timedelta(minutes=15)}), today=today)
         self.assertEqual("15 minutes", period)
 
     def test_calculate_expiry_period_db_object(self):
-        invitation = Invitation(expiry_date=datetime.datetime.today() + datetime.timedelta(minutes=15))
+        invitation = Invitation(expiry_date=dt_now() + datetime.timedelta(minutes=15))
         period = calculate_expiry_period(invitation)
         self.assertTrue(period.endswith("minutes"))
 
     def test_calculate_expiry_period_with_today_hour(self):
-        today = datetime.datetime.today()
+        today = dt_now()
         invitation = Invitation(expiry_date=today + datetime.timedelta(hours=1))
         period = calculate_expiry_period(invitation, today=today)
         self.assertEqual("1 hour", period)
 
     def test_calculate_expiry_period_with_today_day(self):
-        today = datetime.datetime.today()
+        today = dt_now()
         invitation = Invitation(expiry_date=today + datetime.timedelta(days=1))
         period = calculate_expiry_period(invitation, today=today)
         self.assertEqual("1 day", period)

--- a/server/test/db/test_domain.py
+++ b/server/test/db/test_domain.py
@@ -1,19 +1,16 @@
 from sqlalchemy.exc import IntegrityError
 
 from server.db.db import db
-from server.db.domain import Collaboration, CollaborationMembership, Invitation, OrganisationInvitation, User
+from server.db.domain import Collaboration, CollaborationMembership, Invitation, OrganisationInvitation
 from server.test.abstract_test import AbstractTest
-from server.test.seed import co_ai_computing_name, user_boss_name
+from server.test.seed import co_ai_computing_name
 
 
 class TestModels(AbstractTest):
 
     def test_collaboration(self):
         collaboration = self.find_entity_by_name(Collaboration, co_ai_computing_name)
-        self.assertFalse(collaboration.is_admin(999))
-
-        admin = self.find_entity_by_name(User, user_boss_name)
-        self.assertTrue(collaboration.is_admin(admin.id))
+        self.assertEqual(False, collaboration.is_admin(999))
 
     def test_invitation_role(self):
         Invitation.validate_role("admin")

--- a/server/test/db/test_domain.py
+++ b/server/test/db/test_domain.py
@@ -1,16 +1,19 @@
 from sqlalchemy.exc import IntegrityError
 
 from server.db.db import db
-from server.db.domain import Collaboration, CollaborationMembership, Invitation, OrganisationInvitation
+from server.db.domain import Collaboration, CollaborationMembership, Invitation, OrganisationInvitation, User
 from server.test.abstract_test import AbstractTest
-from server.test.seed import co_ai_computing_name
+from server.test.seed import co_ai_computing_name, user_boss_name
 
 
 class TestModels(AbstractTest):
 
     def test_collaboration(self):
         collaboration = self.find_entity_by_name(Collaboration, co_ai_computing_name)
-        self.assertEqual(False, collaboration.is_admin(999))
+        self.assertFalse(collaboration.is_admin(999))
+
+        admin = self.find_entity_by_name(User, user_boss_name)
+        self.assertTrue(collaboration.is_admin(admin.id))
 
     def test_invitation_role(self):
         Invitation.validate_role("admin")

--- a/server/test/scim/test_group_template.py
+++ b/server/test/scim/test_group_template.py
@@ -1,15 +1,15 @@
-import datetime
 import uuid
 
 from server.db.domain import Group
 from server.scim.group_template import find_group_by_id_template
 from server.test.abstract_test import AbstractTest
+from server.tools import dt_now
 
 
 class TestGroupTemplate(AbstractTest):
 
     def test_find_group_by_id_template(self):
-        now = datetime.datetime.now()
+        now = dt_now()
         group = Group(identifier=uuid.uuid4(), created_at=now, updated_at=now)
         result = find_group_by_id_template(group)
 

--- a/server/test/scim/test_user_template.py
+++ b/server/test/scim/test_user_template.py
@@ -1,15 +1,15 @@
-import datetime
 import uuid
 from unittest import TestCase
 
 from server.db.domain import User
 from server.scim.user_template import find_user_by_id_template
+from server.tools import dt_now
 
 
 class TestUserTemplate(TestCase):
 
     def test_find_user_by_id_template(self):
-        now = datetime.datetime.now()
+        now = dt_now()
         user = User(external_id=uuid.uuid4(), name="John Doe", email="jdoe@domain.com", updated_at=now, created_at=now)
         result = find_user_by_id_template(user)
 

--- a/server/test/seed.py
+++ b/server/test/seed.py
@@ -15,7 +15,7 @@ from server.db.domain import (User, Organisation, OrganisationMembership, Servic
                               SchacHomeOrganisation, SshKey, ServiceGroup, ServiceInvitation, ServiceMembership,
                               ServiceAup, UserToken, UserIpNetwork, Tag, PamSSOSession, IpNetwork, ServiceToken,
                               ServiceRequest, Unit)
-from server.tools import dt_now
+from server.tools import dt_now, dt_today
 
 # users
 user_boss_name = "The Boss"
@@ -302,8 +302,7 @@ def seed(db, app_config, skip_seed=False):
     persist_instance(db, api_key_uuc, api_key_uva)
 
     organisation_invitation_roger = OrganisationInvitation(message="Please join", hash=unihard_invitation_hash,
-                                                           expiry_date=datetime.date.today() + datetime.timedelta(
-                                                               days=14),
+                                                           expiry_date=dt_today() + datetime.timedelta(days=14),
                                                            invitee_email="roger@example.org", organisation=uuc,
                                                            units=[uuc_unit_research],
                                                            intended_role="admin",
@@ -312,8 +311,7 @@ def seed(db, app_config, skip_seed=False):
                                                                   "really, really, really \n really, "
                                                                   "really, really \n want to...",
                                                           hash=unihard_invitation_expired_hash,
-                                                          expiry_date=datetime.date.today() - datetime.timedelta(
-                                                              days=21),
+                                                          expiry_date=dt_today() - datetime.timedelta(days=21),
                                                           intended_role="admin",
                                                           invitee_email="pass@example.org", organisation=uuc, user=john)
     persist_instance(db, organisation_invitation_roger, organisation_invitation_pass)
@@ -479,14 +477,13 @@ def seed(db, app_config, skip_seed=False):
                      service_token_storage_scim, service_token_wiki_introspection, service_token_wiki_scim)
 
     service_invitation_cloud = ServiceInvitation(message="Please join", hash=service_invitation_cloud_hash,
-                                                 expiry_date=datetime.date.today() + datetime.timedelta(days=14),
+                                                 expiry_date=dt_today() + datetime.timedelta(days=14),
                                                  invitee_email="admin@cloud.org", service=cloud,
                                                  intended_role="admin",
                                                  user=john)
     service_invitation_wiki_expired = ServiceInvitation(message="Please join",
                                                         hash=service_invitation_wiki_expired_hash,
-                                                        expiry_date=datetime.date.today() - datetime.timedelta(
-                                                            days=21),
+                                                        expiry_date=dt_today() - datetime.timedelta(days=21),
                                                         intended_role="admin",
                                                         invitee_email="pass@wiki.org", service=wiki, user=john)
     persist_instance(db, service_invitation_cloud, service_invitation_wiki_expired)
@@ -676,7 +673,7 @@ def seed(db, app_config, skip_seed=False):
                                 expiry_date=default_expiry_date(), user=admin, message="Please join...",
                                 intended_role="member", groups=[group_science], status="open")
     invitation_noway = Invitation(hash=invitation_hash_no_way, invitee_email="noway@ex.org", collaboration=ai_computing,
-                                  expiry_date=datetime.date.today() - datetime.timedelta(days=21), user=admin,
+                                  expiry_date=dt_today() - datetime.timedelta(days=21), user=admin,
                                   intended_role="member", status="expired",
                                   message="Let me please join as I really, really, really \n really, "
                                           "really, really \n want to...")

--- a/server/test/seed.py
+++ b/server/test/seed.py
@@ -15,6 +15,7 @@ from server.db.domain import (User, Organisation, OrganisationMembership, Servic
                               SchacHomeOrganisation, SshKey, ServiceGroup, ServiceInvitation, ServiceMembership,
                               ServiceAup, UserToken, UserIpNetwork, Tag, PamSSOSession, IpNetwork, ServiceToken,
                               ServiceRequest, Unit)
+from server.tools import dt_now
 
 # users
 user_boss_name = "The Boss"
@@ -195,7 +196,7 @@ def seed(db, app_config, skip_seed=False):
                          external_id="c5ed5e18-b6aa-48f2-8849-a68a8cfe39a8")
     # User seed for suspend testing
     retention = app_config.retention
-    current_time = datetime.datetime.utcnow()
+    current_time = dt_now()
     retention_date = current_time - datetime.timedelta(days=retention.allowed_inactive_period_days + 1)
     retention_warning_date = retention_date + datetime.timedelta(days=retention.reminder_suspend_period_days)
 
@@ -229,11 +230,11 @@ def seed(db, app_config, skip_seed=False):
     notification_gets_suspended_old = SuspendNotification(user=user_suspend_warning, sent_at=warning_date_old,
                                                           is_suspension=True, is_warning=True)
 
-    warning_date = datetime.datetime.utcnow() - datetime.timedelta(days=retention.reminder_suspend_period_days + 1)
+    warning_date = dt_now() - datetime.timedelta(days=retention.reminder_suspend_period_days + 1)
     notification_gets_suspended = SuspendNotification(user=user_gets_suspended, sent_at=warning_date,
                                                       is_suspension=True, is_warning=True)
 
-    warning_date = datetime.datetime.utcnow() - datetime.timedelta(days=retention.remove_suspended_users_period_days) \
+    warning_date = dt_now() - datetime.timedelta(days=retention.remove_suspended_users_period_days) \
                    + datetime.timedelta(days=retention.reminder_expiry_period_days - 1)
     notification_suspension_warning = SuspendNotification(user=user_deletion_warning, sent_at=warning_date,
                                                           is_suspension=True, is_warning=False)

--- a/server/tools.py
+++ b/server/tools.py
@@ -20,3 +20,7 @@ def read_file(file_name: str) -> str:
 
 def dt_now() -> datetime:
     return datetime.now(timezone.utc)
+
+
+def dt_today() -> datetime:
+    return dt_now().replace(hour=0, minute=0, second=0, microsecond=0)

--- a/server/tools.py
+++ b/server/tools.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from datetime import datetime, timezone
 from os.path import exists
 
 from werkzeug.exceptions import BadRequest
@@ -15,3 +16,7 @@ def read_file(file_name: str) -> str:
             return f.read()
     else:
         raise BadRequest()
+
+
+def dt_now() -> datetime:
+    return datetime.now(timezone.utc)


### PR DESCRIPTION
Starting in python 3.12, the utc-based datetime functions (`utcfromtimestamp()` and `utcnow()` are deprecated (causing about 2000 warnings when running the integration tests).  

This patch fixed this by using timezone-aware datetimes throughout the code.  The datetimes are automatically converted to UTC-based datetimes on database interaction as described here: https://docs.sqlalchemy.org/en/20/core/custom_types.html#store-timezone-aware-timestamps-as-timezone-naive-utc

I'm not entirely sure that is is the best approach; I've also considered simply introducing a custom `utcnow()` function that wouldn't trigger the warnings.  However, in the current code already `datetime.now()` and `datetime.utcnow()` weren't used consistently.  Towards the future it seems better to standardise on timezone-aware datetimes, mainly because any errors in datetimes are then easily caught by the database type decorator (which will throw an exception if it encounters a datetime without timezone info).