### PR TITLE
make package.json work for both docker & no-docker

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -60,7 +60,7 @@
         "ws": "^8.17.1"
     },
     "scripts": {
-        "start": "DANGEROUSLY_DISABLE_HOST_CHECK=true GENERATE_SOURCEMAP=false SBS_SERVER=localhost:8080 react-scripts start",
+        "start": "DANGEROUSLY_DISABLE_HOST_CHECK=true GENERATE_SOURCEMAP=false SBS_SERVER=${SBS_SERVER:-localhost:8080} react-scripts start",
         "build": "DANGEROUSLY_DISABLE_HOST_CHECK=true GENERATE_SOURCEMAP=true react-scripts build",
         "test": "DANGEROUSLY_DISABLE_HOST_CHECK=true GENERATE_SOURCEMAP=false react-scripts test --transformIgnorePatterns 'node_modules/(?!i18n-js)/'",
         "analyze": "source-map-explorer build/static/js/main.*.js "


### PR DESCRIPTION
@oharsta Small adjustment to package.json. In Docker Compose the SBS_SERVER was already set, pointing at the backend-container. Your latest adjustment was overruling that. The end result was: No-Docker dev runs OK, Docker dev Not-OK.
This adjustment satisfies both ways of developing.