### PR TITLE
Issue 497 SCIM urn configurable

### DIFF
--- a/etc/config.yml
+++ b/etc/config.yml
@@ -40,6 +40,7 @@ oidc:
   #Note that the paths for these  uri's is hardcoded and only domain and port differ per environment
   redirect_uri: ${BASE_URL}/api/users/resume-session
   continue_eduteams_redirect_uri: ${AUDIENCE}/continue
+  continue_eb_redirect_uri: https://engine.(.*)surfconext.nl
   second_factor_authentication_required: True
   totp_token_name: "SRAM local"
   # The client_id of SBS. Most likely to equal the oidc.client_id
@@ -213,6 +214,8 @@ scim_sweep:
   enabled: True
   # How often do we check if scim sweeps are needed per service
   cron_minutes_expression: "*/15"
+
+scim_schema_sram: "urn:mace:surf.nl:sram:scim:extension"
 
 ldap:
   url: "${LDAP_URL}"

--- a/server/__main__.py
+++ b/server/__main__.py
@@ -45,7 +45,6 @@ from server.api.organisation_membership import organisation_membership_api
 from server.api.organisations_services import organisations_services_api
 from server.api.pam_websso import pam_websso_api
 from server.api.plsc import plsc_api
-from server.api.scim import scim_api
 from server.api.service import service_api
 from server.api.service_aups import service_aups_api
 from server.api.service_connection_request import service_connection_request_api
@@ -107,6 +106,12 @@ def _init_logging(log_to_stdout: bool):
 config_file_location = os.environ.get("CONFIG", "config/config.yml")
 config = munchify(yaml.load(read_file(config_file_location), Loader=yaml.FullLoader))
 config.base_url = config.base_url[:-1] if config.base_url.endswith("/") else config.base_url
+
+if hasattr(config, 'scim_schema_sram'):
+    init_scim_schemas(config.scim_schema_sram)
+
+# Do only import the SCIM enndpoints after scim schema is initialized !
+from server.api.scim import scim_api
 
 test = os.environ.get("TESTING")
 profile = os.environ.get("PROFILE")
@@ -186,7 +191,6 @@ init_executor(app, blocking=False)
 app.app_config = config
 app.app_config["profile"] = profile
 
-init_scim_schemas(app)
 init_swagger(app)
 
 Migrate(app, db)

--- a/server/__main__.py
+++ b/server/__main__.py
@@ -72,6 +72,8 @@ from server.swagger.conf import init_swagger, swagger_specs
 from server.templates import invitation_role
 from server.tools import read_file
 from server.cli import register_commands
+from server.scim.schema_template import init_scim_schemas
+
 
 def _init_logging(log_to_stdout: bool):
     # https://github.com/python-pillow/Pillow/issues/5096
@@ -184,6 +186,7 @@ init_executor(app, blocking=False)
 app.app_config = config
 app.app_config["profile"] = profile
 
+init_scim_schemas(app)
 init_swagger(app)
 
 Migrate(app, db)

--- a/server/api/scim.py
+++ b/server/api/scim.py
@@ -100,7 +100,7 @@ def service_users():
     # note: we only support "eq" here.
     if filter_param:
         query = urllib.parse.unquote(filter_param)
-        if not query.lower().startswith(f"{get_scim_schema_sram_user()()}.eduPersonUniqueId".lower()):
+        if not query.lower().startswith(f"{get_scim_schema_sram_user()}.eduPersonUniqueId".lower()):
             raise NotImplementedError(f"Not supported filter {query}")
         uid = re.search(r"(?:'|\")(.*)(?:'|\")", query).group(1)
         users = User.query.filter(func.lower(User.uid) == func.lower(uid)).all()

--- a/server/api/scim.py
+++ b/server/api/scim.py
@@ -25,8 +25,8 @@ from server.scim.resource_type_template import resource_type_template, resource_
 from server.scim.schema_template import schemas_template, \
     schema_core_user_template, schema_core_group_template, \
     schema_sram_user_template, schema_sram_group_template, \
-    SCIM_SCHEMA_CORE_USER, SCIM_SCHEMA_CORE_GROUP, \
-    SCIM_SCHEMA_SRAM_USER, SCIM_SCHEMA_SRAM_GROUP
+    get_scim_schema_sram_user, get_scim_schema_sram_group, \
+    SCIM_SCHEMA_CORE_USER, SCIM_SCHEMA_CORE_GROUP
 from server.scim.sweep import perform_sweep
 from server.scim.user_template import find_users_template, find_user_by_id_template, version_value
 
@@ -53,13 +53,13 @@ def schema_core_group():
     return schema_core_group_template(), 200
 
 
-@scim_api.route(f"/Schemas/{SCIM_SCHEMA_SRAM_USER}", methods=["GET"], strict_slashes=False)
+@scim_api.route(f"/Schemas/{get_scim_schema_sram_user()}", methods=["GET"], strict_slashes=False)
 @json_endpoint
 def schema_sram_user():
     return schema_sram_user_template(), 200
 
 
-@scim_api.route(f"/Schemas/{SCIM_SCHEMA_SRAM_GROUP}", methods=["GET"], strict_slashes=False)
+@scim_api.route(f"/Schemas/{get_scim_schema_sram_group()}", methods=["GET"], strict_slashes=False)
 @json_endpoint
 def schema_sram_group():
     return schema_sram_group_template(), 200
@@ -100,7 +100,7 @@ def service_users():
     # note: we only support "eq" here.
     if filter_param:
         query = urllib.parse.unquote(filter_param)
-        if not query.lower().startswith(f"{SCIM_SCHEMA_SRAM_USER}.eduPersonUniqueId".lower()):
+        if not query.lower().startswith(f"{get_scim_schema_sram_user()()}.eduPersonUniqueId".lower()):
             raise NotImplementedError(f"Not supported filter {query}")
         uid = re.search(r"(?:'|\")(.*)(?:'|\")", query).group(1)
         users = User.query.filter(func.lower(User.uid) == func.lower(uid)).all()

--- a/server/config/test_config.yml
+++ b/server/config/test_config.yml
@@ -218,6 +218,8 @@ scim_sweep:
   # How often do we check if scim sweeps are needed per service
   cron_minutes_expression: "*/15"
 
+scim_schema_sram: "urn:mace:surf.nl:sram:scim:extension"
+
 ldap:
   url: "ldap://ldap.example.com/dc=example,dc=com"
   bind_account: "cn=admin,dc=entity_id,dc=services,dc=sram-tst,dc=surf,dc=nl"

--- a/server/etc/config.yml
+++ b/server/etc/config.yml
@@ -219,6 +219,8 @@ scim_sweep:
   # How often do we check if scim sweeps are needed per service
   cron_minutes_expression: "*/15"
 
+scim_schema_sram: "urn:mace:surf.nl:sram:scim:extension"
+
 ldap:
   url: "ldap://ldap.example.com/dc=example,dc=com"
   bind_account: "cn=admin,dc=entity_id,dc=services,dc=sram-tst,dc=surf,dc=nl"

--- a/server/scim/group_template.py
+++ b/server/scim/group_template.py
@@ -3,8 +3,7 @@ from typing import Union, List
 from server.api.base import application_base_url
 from server.db.domain import Group, Collaboration, CollaborationMembership
 from server.scim import SCIM_URL_PREFIX, EXTERNAL_ID_POST_FIX
-from server.scim.schema_template import \
-    SCIM_SCHEMA_CORE_GROUP, SCIM_SCHEMA_SRAM_GROUP, SCIM_API_MESSAGES
+from server.scim.schema_template import SCIM_SCHEMA_CORE_GROUP, SCIM_API_MESSAGES
 from server.scim.user_template import version_value, date_time_format, replace_none_values
 
 
@@ -17,6 +16,8 @@ def _meta_info(group: Union[Group, Collaboration]):
 
 
 def create_group_template(group: Union[Group, Collaboration], membership_scim_objects):
+    from server.scim.schema_template import get_scim_schema_sram_group
+
     def link(name: str, value: str):
         return {
             'name': name,
@@ -53,12 +54,12 @@ def create_group_template(group: Union[Group, Collaboration], membership_scim_ob
     return replace_none_values({
         "schemas": [
             SCIM_SCHEMA_CORE_GROUP,
-            SCIM_SCHEMA_SRAM_GROUP
+            get_scim_schema_sram_group()
         ],
         "externalId": f"{group.identifier}{EXTERNAL_ID_POST_FIX}",
         "displayName": group.name,
         "members": sorted_members,
-        SCIM_SCHEMA_SRAM_GROUP: scim_sram_extension
+        get_scim_schema_sram_group(): scim_sram_extension
     })
 
 

--- a/server/scim/resource_type_template.py
+++ b/server/scim/resource_type_template.py
@@ -1,7 +1,6 @@
 from server.scim.schema_template import \
     SCIM_API_MESSAGES, SCIM_SCHEMA_CORE, \
-    SCIM_SCHEMA_CORE_USER, SCIM_SCHEMA_CORE_GROUP, \
-    SCIM_SCHEMA_SRAM_USER, SCIM_SCHEMA_SRAM_GROUP
+    SCIM_SCHEMA_CORE_USER, SCIM_SCHEMA_CORE_GROUP
 
 
 def _resource_type(name, schema):
@@ -22,18 +21,22 @@ def _resource_type(name, schema):
 
 
 def resource_type_user_template():
+    from server.scim.schema_template import get_scim_schema_sram_user
+
     return _resource_type("User", SCIM_SCHEMA_CORE_USER) | {
         "schemaExtensions": [{
-            "schema": SCIM_SCHEMA_SRAM_USER,
+            "schema": get_scim_schema_sram_user(),
             "required": True
         }]
     }
 
 
 def resource_type_group_template():
+    from server.scim.schema_template import get_scim_schema_sram_group
+
     return _resource_type("Group", SCIM_SCHEMA_CORE_GROUP) | {
         "schemaExtensions": [{
-            "schema": SCIM_SCHEMA_SRAM_GROUP,
+            "schema": get_scim_schema_sram_group(),
             "required": True
         }]
     }

--- a/server/scim/schema_template.py
+++ b/server/scim/schema_template.py
@@ -4,9 +4,31 @@ SCIM_SCHEMA_CORE = "urn:ietf:params:scim:schemas:core:2.0"
 SCIM_SCHEMA_CORE_USER = f"{SCIM_SCHEMA_CORE}:User"
 SCIM_SCHEMA_CORE_GROUP = f"{SCIM_SCHEMA_CORE}:Group"
 
-SCIM_SCHEMA_SRAM = "urn:mace:surf.nl:sram:scim:extension"
+# Default values that are safe to use during import
+SCIM_SCHEMA_SRAM = "urn:example:sram:scim:schemas:1.0"  # Default
 SCIM_SCHEMA_SRAM_USER = f"{SCIM_SCHEMA_SRAM}:User"
 SCIM_SCHEMA_SRAM_GROUP = f"{SCIM_SCHEMA_SRAM}:Group"
+
+
+def init_scim_schemas(app):
+    """Initialize SCIM schemas from app config"""
+    global SCIM_SCHEMA_SRAM, SCIM_SCHEMA_SRAM_USER, SCIM_SCHEMA_SRAM_GROUP
+    if hasattr(app.app_config, 'scim_schema_sram'):
+        SCIM_SCHEMA_SRAM = app.app_config.scim_schema_sram
+        SCIM_SCHEMA_SRAM_USER = f"{SCIM_SCHEMA_SRAM}:User"
+        SCIM_SCHEMA_SRAM_GROUP = f"{SCIM_SCHEMA_SRAM}:Group"
+
+
+def get_scim_schema_sram():
+    return SCIM_SCHEMA_SRAM
+
+
+def get_scim_schema_sram_user():
+    return SCIM_SCHEMA_SRAM_USER
+
+
+def get_scim_schema_sram_group():
+    return SCIM_SCHEMA_SRAM_GROUP
 
 
 def _schema(id, attributes):
@@ -147,7 +169,7 @@ def schema_core_user_template():
 
 
 def schema_sram_user_template():
-    return _schema(SCIM_SCHEMA_SRAM_USER, [
+    return _schema(get_scim_schema_sram_user(), [
         {
             "name": "eduPersonScopedAffiliation",
             "type": "string",
@@ -259,7 +281,7 @@ def schema_core_group_template():
 
 
 def schema_sram_group_template():
-    return _schema(SCIM_SCHEMA_SRAM_GROUP, [
+    return _schema(get_scim_schema_sram_group(), [
         {
             "name": "description",
             "type": "string",

--- a/server/scim/schema_template.py
+++ b/server/scim/schema_template.py
@@ -6,17 +6,12 @@ SCIM_SCHEMA_CORE_GROUP = f"{SCIM_SCHEMA_CORE}:Group"
 
 # Default values that are safe to use during import
 SCIM_SCHEMA_SRAM = "urn:example:sram:scim:schemas:1.0"  # Default
-SCIM_SCHEMA_SRAM_USER = f"{SCIM_SCHEMA_SRAM}:User"
-SCIM_SCHEMA_SRAM_GROUP = f"{SCIM_SCHEMA_SRAM}:Group"
 
 
-def init_scim_schemas(app):
-    """Initialize SCIM schemas from app config"""
-    global SCIM_SCHEMA_SRAM, SCIM_SCHEMA_SRAM_USER, SCIM_SCHEMA_SRAM_GROUP
-    if hasattr(app.app_config, 'scim_schema_sram'):
-        SCIM_SCHEMA_SRAM = app.app_config.scim_schema_sram
-        SCIM_SCHEMA_SRAM_USER = f"{SCIM_SCHEMA_SRAM}:User"
-        SCIM_SCHEMA_SRAM_GROUP = f"{SCIM_SCHEMA_SRAM}:Group"
+def init_scim_schemas(urn):
+    """Initialize SCIM SRAM schemas with urn"""
+    global SCIM_SCHEMA_SRAM
+    SCIM_SCHEMA_SRAM = urn
 
 
 def get_scim_schema_sram():
@@ -24,11 +19,11 @@ def get_scim_schema_sram():
 
 
 def get_scim_schema_sram_user():
-    return SCIM_SCHEMA_SRAM_USER
+    return f"{get_scim_schema_sram()}:User"
 
 
 def get_scim_schema_sram_group():
-    return SCIM_SCHEMA_SRAM_GROUP
+    return f"{get_scim_schema_sram()}:Group"
 
 
 def _schema(id, attributes):

--- a/server/test/api/test_mock_scim.py
+++ b/server/test/api/test_mock_scim.py
@@ -2,6 +2,7 @@ from server.api.base import application_base_url
 from server.api.mock_scim import HTTP_CALLS_KEY, DATABASE_KEY
 from server.db.domain import User, Collaboration, Service
 from server.scim import EXTERNAL_ID_POST_FIX
+from server.scim.schema_template import get_scim_schema_sram_group
 from server.scim.group_template import create_group_template, scim_member_object, update_group_template
 from server.scim.user_template import create_user_template
 from server.test.abstract_test import AbstractTest
@@ -10,12 +11,6 @@ from flask import current_app
 
 
 class TestMockScim(AbstractTest):
-
-    def setUp(self):
-        from server.scim.schema_template import get_scim_schema_sram_group
-
-        self.SCIM_SCHEMA_SRAM_GROUP = get_scim_schema_sram_group()
-        super(TestMockScim, self).setUp()
 
     # Very lengthy flow test, but we need the ordering right
     def test_mock_scim_flow(self):
@@ -89,7 +84,7 @@ class TestMockScim(AbstractTest):
                        headers=headers,
                        with_basic_auth=False)
         collaboration = self.find_entity_by_name(Collaboration, co_ai_computing_name)
-        self.assertEqual(collaboration.global_urn, res[self.SCIM_SCHEMA_SRAM_GROUP]["urn"])
+        self.assertEqual(collaboration.global_urn, res[get_scim_schema_sram_group()]["urn"])
         self.assertEqual(scim_id_user, res["members"][0]["value"])
 
         # Find the group by externalId

--- a/server/test/api/test_mock_scim.py
+++ b/server/test/api/test_mock_scim.py
@@ -13,7 +13,7 @@ class TestMockScim(AbstractTest):
 
     def setUp(self):
         from server.scim.schema_template import get_scim_schema_sram_group
-        
+
         self.SCIM_SCHEMA_SRAM_GROUP = get_scim_schema_sram_group()
         super(TestMockScim, self).setUp()
 

--- a/server/test/api/test_mock_scim.py
+++ b/server/test/api/test_mock_scim.py
@@ -3,7 +3,6 @@ from server.api.mock_scim import HTTP_CALLS_KEY, DATABASE_KEY
 from server.db.domain import User, Collaboration, Service
 from server.scim import EXTERNAL_ID_POST_FIX
 from server.scim.group_template import create_group_template, scim_member_object, update_group_template
-from server.scim.schema_template import SCIM_SCHEMA_SRAM_GROUP
 from server.scim.user_template import create_user_template
 from server.test.abstract_test import AbstractTest
 from server.test.seed import user_sarah_name, co_ai_computing_name, service_cloud_name
@@ -11,6 +10,12 @@ from flask import current_app
 
 
 class TestMockScim(AbstractTest):
+
+    def setUp(self):
+        from server.scim.schema_template import get_scim_schema_sram_group
+        
+        self.SCIM_SCHEMA_SRAM_GROUP = get_scim_schema_sram_group()
+        super(TestMockScim, self).setUp()
 
     # Very lengthy flow test, but we need the ordering right
     def test_mock_scim_flow(self):
@@ -84,7 +89,7 @@ class TestMockScim(AbstractTest):
                        headers=headers,
                        with_basic_auth=False)
         collaboration = self.find_entity_by_name(Collaboration, co_ai_computing_name)
-        self.assertEqual(collaboration.global_urn, res[SCIM_SCHEMA_SRAM_GROUP]["urn"])
+        self.assertEqual(collaboration.global_urn, res[self.SCIM_SCHEMA_SRAM_GROUP]["urn"])
         self.assertEqual(scim_id_user, res["members"][0]["value"])
 
         # Find the group by externalId

--- a/server/test/api/test_scim.py
+++ b/server/test/api/test_scim.py
@@ -10,15 +10,20 @@ from server.db.db import db
 from server.db.domain import User, Collaboration, Group, Service
 from server.scim import EXTERNAL_ID_POST_FIX
 from server.scim.resource_type_template import resource_type_template
-from server.scim.schema_template import schemas_template, SCIM_SCHEMA_SRAM_USER
 from server.scim.user_template import version_value
 from server.test.abstract_test import AbstractTest
 from server.test.seed import service_network_token, user_jane_name, co_ai_computing_name, group_ai_researchers, \
     service_network_name, service_wiki_token, service_wiki_name
 from server.tools import read_file
+from server.scim.schema_template import schemas_template
 
 
 class TestScim(AbstractTest):
+
+    def setUp(self):
+        from server.scim.schema_template import get_scim_schema_sram_user
+        self.SCIM_SCHEMA_SRAM_USER = get_scim_schema_sram_user()
+        super(TestScim, self).setUp()
 
     def test_users(self):
         res = self.get("/api/scim/v2/Users", headers={"Authorization": f"bearer {service_network_token}"},
@@ -96,7 +101,7 @@ class TestScim(AbstractTest):
             self.get(f"/api/scim/v2{resource['meta']['location']}", response_status_code=200)
 
     def test_users_filter(self):
-        query = urllib.parse.quote(f"{SCIM_SCHEMA_SRAM_USER}.eduPersonUniqueId eq \"urn:john\"")
+        query = urllib.parse.quote(f"{self.SCIM_SCHEMA_SRAM_USER}.eduPersonUniqueId eq \"urn:john\"")
         res = self.get("/api/scim/v2/Users",
                        query_data={"filter": query},
                        headers={"Authorization": f"bearer {service_network_token}"},
@@ -104,7 +109,7 @@ class TestScim(AbstractTest):
         self.assertEqual(1, len(res["Resources"]))
 
     def test_users_filter_single_quote(self):
-        query = urllib.parse.quote(f"{SCIM_SCHEMA_SRAM_USER}.eduPersonUniqueId eq 'urn:john'")
+        query = urllib.parse.quote(f"{self.SCIM_SCHEMA_SRAM_USER}.eduPersonUniqueId eq 'urn:john'")
         res = self.get("/api/scim/v2/Users",
                        query_data={"filter": query},
                        headers={"Authorization": f"bearer {service_network_token}"},
@@ -112,7 +117,7 @@ class TestScim(AbstractTest):
         self.assertEqual(1, len(res["Resources"]))
 
     def test_users_filter_not_implemented(self):
-        query = urllib.parse.quote(f"{SCIM_SCHEMA_SRAM_USER}.voPersonExternalId eq 'urn:john'")
+        query = urllib.parse.quote(f"{self.SCIM_SCHEMA_SRAM_USER}.voPersonExternalId eq 'urn:john'")
         self.get("/api/scim/v2/Users",
                  query_data={"filter": query},
                  headers={"Authorization": f"bearer {service_network_token}"},

--- a/server/test/api/test_scim.py
+++ b/server/test/api/test_scim.py
@@ -15,15 +15,10 @@ from server.test.abstract_test import AbstractTest
 from server.test.seed import service_network_token, user_jane_name, co_ai_computing_name, group_ai_researchers, \
     service_network_name, service_wiki_token, service_wiki_name
 from server.tools import read_file
-from server.scim.schema_template import schemas_template
+from server.scim.schema_template import schemas_template, get_scim_schema_sram_user
 
 
 class TestScim(AbstractTest):
-
-    def setUp(self):
-        from server.scim.schema_template import get_scim_schema_sram_user
-        self.SCIM_SCHEMA_SRAM_USER = get_scim_schema_sram_user()
-        super(TestScim, self).setUp()
 
     def test_users(self):
         res = self.get("/api/scim/v2/Users", headers={"Authorization": f"bearer {service_network_token}"},
@@ -101,7 +96,7 @@ class TestScim(AbstractTest):
             self.get(f"/api/scim/v2{resource['meta']['location']}", response_status_code=200)
 
     def test_users_filter(self):
-        query = urllib.parse.quote(f"{self.SCIM_SCHEMA_SRAM_USER}.eduPersonUniqueId eq \"urn:john\"")
+        query = urllib.parse.quote(f"{get_scim_schema_sram_user()}.eduPersonUniqueId eq \"urn:john\"")
         res = self.get("/api/scim/v2/Users",
                        query_data={"filter": query},
                        headers={"Authorization": f"bearer {service_network_token}"},
@@ -109,7 +104,7 @@ class TestScim(AbstractTest):
         self.assertEqual(1, len(res["Resources"]))
 
     def test_users_filter_single_quote(self):
-        query = urllib.parse.quote(f"{self.SCIM_SCHEMA_SRAM_USER}.eduPersonUniqueId eq 'urn:john'")
+        query = urllib.parse.quote(f"{get_scim_schema_sram_user()}.eduPersonUniqueId eq 'urn:john'")
         res = self.get("/api/scim/v2/Users",
                        query_data={"filter": query},
                        headers={"Authorization": f"bearer {service_network_token}"},
@@ -117,7 +112,7 @@ class TestScim(AbstractTest):
         self.assertEqual(1, len(res["Resources"]))
 
     def test_users_filter_not_implemented(self):
-        query = urllib.parse.quote(f"{self.SCIM_SCHEMA_SRAM_USER}.voPersonExternalId eq 'urn:john'")
+        query = urllib.parse.quote(f"{get_scim_schema_sram_user()}.voPersonExternalId eq 'urn:john'")
         self.get("/api/scim/v2/Users",
                  query_data={"filter": query},
                  headers={"Authorization": f"bearer {service_network_token}"},

--- a/server/test/conftest.py
+++ b/server/test/conftest.py
@@ -12,6 +12,7 @@ from munch import munchify
 
 from server.db.db import db_migrations
 from server.tools import read_file
+from server.scim.schema_template import init_scim_schemas
 
 
 def pytest_sessionstart():
@@ -43,3 +44,6 @@ def use_random_db(request, worker_id):
 
     os.environ['SBS_DB_URI_OVERRIDE'] = database_uri
     db_migrations(database_uri)
+
+    if hasattr(config, 'scim_schema_sram'):
+        init_scim_schemas(config.scim_schema_sram)

--- a/server/test/scim/test_sweep.py
+++ b/server/test/scim/test_sweep.py
@@ -10,7 +10,6 @@ from server.db.domain import Service, Group, User, Collaboration
 from server.scim import SCIM_GROUPS
 from server.scim.group_template import create_group_template, scim_member_object
 from server.scim.repo import all_scim_groups_by_service
-from server.scim.schema_template import SCIM_SCHEMA_SRAM_GROUP
 from server.scim.sweep import perform_sweep, _all_remote_scim_objects, _group_changed, _user_changed
 from server.scim.user_template import create_user_template, find_user_by_id_template
 
@@ -23,6 +22,9 @@ from server.tools import read_file
 class TestSweep(AbstractTest):
 
     def setUp(self):
+        from server.scim.schema_template import get_scim_schema_sram_group
+        self.SCIM_SCHEMA_SRAM_GROUP = get_scim_schema_sram_group()
+
         super(TestSweep, self).setUp()
         self.add_bearer_token_to_services()
 
@@ -178,7 +180,7 @@ class TestSweep(AbstractTest):
         self.assertTrue(_group_changed(collaboration, remote_group, remote_scim_users))
 
         # remote has other links
-        remote_group[SCIM_SCHEMA_SRAM_GROUP]['links'] = [{'name': 'Het Paard van Sinterklaas', 'value': 'Ohzosnel'}]
+        remote_group[self.SCIM_SCHEMA_SRAM_GROUP]['links'] = [{'name': 'Het Paard van Sinterklaas', 'value': 'Ohzosnel'}]
         self.assertTrue(_group_changed(collaboration, remote_group, remote_scim_users))
 
     def test_group_changed_links_logo(self):
@@ -186,7 +188,7 @@ class TestSweep(AbstractTest):
         remote_group, remote_scim_users = self._construct_group_changed_parameters(collaboration)
 
         # remote has different logo
-        for link in remote_group[SCIM_SCHEMA_SRAM_GROUP]['links']:
+        for link in remote_group[self.SCIM_SCHEMA_SRAM_GROUP]['links']:
             if link['name'] == 'logo':
                 link['value'] = 'https://expample.com/sinterklaas.jpg'
         self.assertTrue(_group_changed(collaboration, remote_group, remote_scim_users))
@@ -195,7 +197,7 @@ class TestSweep(AbstractTest):
         group = self.find_entity_by_name(Group, group_ai_researchers)
         remote_group, remote_scim_users = self._construct_group_changed_parameters(group)
 
-        remote_group[SCIM_SCHEMA_SRAM_GROUP]['links'] = [{'name': 'changed', 'value': 'changed'}]
+        remote_group[self.SCIM_SCHEMA_SRAM_GROUP]['links'] = [{'name': 'changed', 'value': 'changed'}]
         self.assertTrue(_group_changed(group, remote_group, remote_scim_users))
 
     def test_group_not_changed(self):

--- a/server/test/scim/test_user_template.py
+++ b/server/test/scim/test_user_template.py
@@ -4,6 +4,7 @@ from unittest import TestCase
 
 from server.db.domain import User
 from server.scim.user_template import find_user_by_id_template
+from server.scim.schema_template import SCIM_SCHEMA_SRAM_USER
 from server.tools import dt_now
 
 
@@ -19,4 +20,4 @@ class TestUserTemplate(TestCase):
 
         self.assertEqual(result["displayName"], user.name)
         self.assertEqual(result["name"]["familyName"], "")
-        self.assertEqual(days, result["urn:mace:surf.nl:sram:scim:extension:User"]["sramInactiveDays"])
+        self.assertEqual(days, result[SCIM_SCHEMA_SRAM_USER]["sramInactiveDays"])

--- a/server/test/scim/test_user_template.py
+++ b/server/test/scim/test_user_template.py
@@ -4,13 +4,14 @@ from unittest import TestCase
 
 from server.db.domain import User
 from server.scim.user_template import find_user_by_id_template
-from server.scim.schema_template import SCIM_SCHEMA_SRAM_USER
 from server.tools import dt_now
 
 
 class TestUserTemplate(TestCase):
 
     def test_find_user_by_id_template(self):
+        from server.scim.schema_template import get_scim_schema_sram_user
+
         now = dt_now()
         days = 365 * 2
         last_login_date = now - datetime.timedelta(days=(days), weeks=3)
@@ -20,4 +21,4 @@ class TestUserTemplate(TestCase):
 
         self.assertEqual(result["displayName"], user.name)
         self.assertEqual(result["name"]["familyName"], "")
-        self.assertEqual(days, result[SCIM_SCHEMA_SRAM_USER]["sramInactiveDays"])
+        self.assertEqual(days, result[get_scim_schema_sram_user()]["sramInactiveDays"])


### PR DESCRIPTION
Made URN for SRAM SCIM User/Group extension configurable

Default value for SRAM extenstion is:
(file: server/scim/schema_template.py)

```
SCIM_SCHEMA_SRAM = "urn:example:sram:scim:schemas:1.0"  # Default
```

Config file, key to configure desired URN:

```
scim_schema_sram: "urn:mace:surf.nl:sram:scim:extension"
```