### PR TITLE
Issue 1567 stress load cli

### DIFF
--- a/client/src/api/index.js
+++ b/client/src/api/index.js
@@ -967,10 +967,6 @@ export function dbDemoSeed() {
     return fetchJson("/api/system/demo_seed");
 }
 
-export function dbStressSeed() {
-    return fetchJson("/api/system/stress_seed");
-}
-
 export function clearAuditLogs() {
     return fetchDelete("/api/system/clear-audit-logs");
 }

--- a/client/src/locale/en.js
+++ b/client/src/locale/en.js
@@ -2004,7 +2004,6 @@ const en = {
         runDbSeedConfirmation: "Are you absolutely sure? This will delete all current data",
         runDbSeedInfo: "Delete all data and insert the <strong>TEST</strong> seed",
         runDbDemoSeedInfo: "Delete all data and insert the <strong>TEST+DEMO</strong> seed",
-        runDbStressSeedInfo: "Delete all data and insert the <strong>Anonymous Volume</strong> seed",
         runDbSeed: "Run",
         runClearAuditLogsConfirmation: "Are you absolutely sure you want to delete all entries from the audit logs?",
         cleanSlate: "Delete everything",

--- a/client/src/locale/nl.js
+++ b/client/src/locale/nl.js
@@ -2004,7 +2004,6 @@ const nl = {
         runDbSeedConfirmation: "Weet je het zeker? Hiermee worden alle huidige gegevens verwijderd",
         runDbSeedInfo: "Verwijder alle gegevens en voeg de <strong>TEST</strong> gegevens toe",
         runDbDemoSeedInfo: "Verwijder alle gegevens en voeg de <strong>TEST+DEMO</strong> gegevens toe",
-        runDbStressSeedInfo: "Verwijder alle gegevens en voeg de <strong>Anonieme Data</strong> gegevens toe",
         runDbSeed: "Voer uit",
         runClearAuditLogsConfirmation: "Weet je zeker dat je alle gegevens uit de audit-logs wil verwijderen?",
         cleanSlate: "Verwijder alles",

--- a/client/src/pages/System.jsx
+++ b/client/src/pages/System.jsx
@@ -156,7 +156,6 @@ class System extends React.Component {
             sweepResults: null,
             seedResult: null,
             demoSeedResult: null,
-            stressSeedResult: null,
             query: "",
             auditLogs: {audit_logs: []},
             filteredAuditLogs: {audit_logs: []},
@@ -558,7 +557,7 @@ class System extends React.Component {
         </div>)
     }
 
-    getSeedTab = (seedResult, demoSeedResult, stressSeedResult) => {
+    getSeedTab = (seedResult, demoSeedResult) => {
         return (<div key="seed" name="seed" label={I18n.t("home.tabs.seed")}>
             <div className="mod-system">
                 <section className={"info-block-container"}>
@@ -568,10 +567,6 @@ class System extends React.Component {
                 <section className={"info-block-container"}>
                     {this.renderDbDemoSeed()}
                     <p className="result">{demoSeedResult}</p>
-                </section>
-                <section className={"info-block-container"}>
-                    {this.renderDbStressSeed()}
-                    <p className="result">{stressSeedResult}</p>
                 </section>
             </div>
         </div>)
@@ -728,24 +723,6 @@ class System extends React.Component {
                     busy: false,
                     demoSeedResult: I18n.t("system.seedResult", {
                         seed: "Demo",
-                        ms: new Date().getMilliseconds() - d.getMilliseconds()
-                    })
-                }, () => window.location.reload());
-            });
-        }
-    }
-
-    doDbStressSeed = showConfirmation => {
-        if (showConfirmation) {
-            this.confirm(() => this.doDbStressSeed(false), I18n.t("system.runDbSeedConfirmation"));
-        } else {
-            this.setState({confirmationDialogOpen: false, busy: true,});
-            const d = new Date();
-            dbStressSeed().then(() => {
-                this.setState({
-                    busy: false,
-                    stressSeedResult: I18n.t("system.seedResult", {
-                        seed: "Stress",
                         ms: new Date().getMilliseconds() - d.getMilliseconds()
                     })
                 }, () => window.location.reload());
@@ -992,21 +969,6 @@ class System extends React.Component {
                                                         onClick={() => this.doDbDemoSeed(true)}/>}
                     {!isEmpty(demoSeedResult) && <Button txt={I18n.t("system.reload")}
                                                          onClick={this.reload} cancelButton={true}/>}
-                </div>
-            </div>
-        );
-    }
-
-    renderDbStressSeed = () => {
-        const {stressSeedResult} = this.state;
-        return (
-            <div className="info-block">
-                <p dangerouslySetInnerHTML={{__html: DOMPurify.sanitize(I18n.t("system.runDbStressSeedInfo"))}}/>
-                <div className="actions">
-                    {isEmpty(stressSeedResult) && <Button txt={I18n.t("system.runDbSeed")}
-                                                          onClick={() => this.doDbStressSeed(true)}/>}
-                    {!isEmpty(stressSeedResult) && <Button txt={I18n.t("system.reload")}
-                                                           onClick={this.reload} cancelButton={true}/>}
                 </div>
             </div>
         );

--- a/client/src/pages/System.jsx
+++ b/client/src/pages/System.jsx
@@ -11,7 +11,6 @@ import {
     clearAuditLogs,
     composition,
     dbDemoSeed,
-    dbStressSeed,
     dbSeed,
     dbStats,
     deleteOrphanUsers,

--- a/server/cli.py
+++ b/server/cli.py
@@ -7,28 +7,33 @@ from flask.cli import with_appcontext
 def register_commands(app):
     """Register Flask CLI commands"""
 
-    app_config = app.app_config
-
-    stress_config = getattr(app_config, 'stress_test', {})
-    num_users = stress_config.get('num_users', 1000)
-    num_orgs = stress_config.get('num_orgs', 50)
-    num_collaborations = stress_config.get('num_collaborations', 200)
-    num_services = stress_config.get('num_services', 30)
-    num_groups = stress_config.get('num_groups', 5)
-
     @app.cli.command("stress-seed")
-    @click.option("--users", default=num_users,
+    @click.option("-u", "--users", default=1000,
                   help="Number of users to create")
-    @click.option("--orgs", default=num_orgs,
+    @click.option("-o", "--orgs", default=50,
                   help="Number of organizations to create")
-    @click.option("--collab", default=num_collaborations,
+    @click.option("-c", "--collab", default=200,
                   help="Number of collaborations to create")
-    @click.option("--services", default=num_services,
+    @click.option("-s", "--services", default=30,
                   help="Number of services to create")
-    @click.option("--groups", default=num_groups,
+    @click.option("-g", "--groups", default=5,
                   help="Number of groups to create")
+    @click.option(
+        "-p", "--probability",
+        default=0.5,
+        type=float,
+        help="""
+            Probability of users being member of a collaboration
+            and services being connected to a collaboration
+        """,
+        show_default=True,
+        callback=lambda ctx, param, value: (
+            value if 0.0 <= value <= 1.0 else
+            click.BadParameter("Probability must be between 0.0 and 1.0")
+        )
+    )
     @with_appcontext
-    def run_stress_seed(users, orgs, collab, services, groups):
+    def run_stress_seed(users, orgs, collab, services, groups, probability):
         """Run stress seed with specified parameters"""
         from server.test.stress_seed import stress_seed
 
@@ -38,6 +43,7 @@ def register_commands(app):
             "num_collaborations": collab,
             "num_services": services,
             "num_groups": groups,
+            "probability": probability,
         }
 
         # Update app_config with the stress test settings

--- a/server/test/stress_seed.py
+++ b/server/test/stress_seed.py
@@ -47,7 +47,7 @@ def stress_seed(db, app_config):
     num_services = stress_config.get('num_services', 30)
     num_groups = stress_config.get('num_groups', 5)
     probability = stress_config.get('probability', 0.5)
-              
+
     logger.debug(
         f"Starting stress seed with: {num_users} users, {num_orgs} orgs, {num_services} services, "
         f"{num_collaborations} collaborations, {num_groups} groups"

--- a/server/test/test_seed.py
+++ b/server/test/test_seed.py
@@ -62,6 +62,7 @@ def test_stress_seed_custom_values(mock_stress_seed, app, runner):
             '--collab', '100',
             '--services', '20',
             '--groups', '50'
+            '-p', '0.8'
         ])
 
     assert result.exit_code == 0

--- a/server/test/test_seed.py
+++ b/server/test/test_seed.py
@@ -61,7 +61,7 @@ def test_stress_seed_custom_values(mock_stress_seed, app, runner):
             '--orgs', '30',
             '--collab', '100',
             '--services', '20',
-            '--groups', '50'
+            '--groups', '50',
             '-p', '0.8'
         ])
 


### PR DESCRIPTION
Adjusted code according to discussion https://github.com/SURFscz/SBS/issues/1567#issuecomment-2847015556

* Removed Frontend option for stress seed
* Removed config file default settings for stress seed
* add CLI option for probability flag.

Sample CLI invocation:
```
$ FLASK_APP='__main__.py' flask stress-seed --help
INFO:main:Initialize server with profile local
INFO  [alembic.runtime.migration] Context impl MySQLImpl.
INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
Usage: flask stress-seed [OPTIONS]

  Run stress seed with specified parameters

Options:
  -u, --users INTEGER      Number of users to create
  -o, --orgs INTEGER       Number of organizations to create
  -c, --collab INTEGER     Number of collaborations to create
  -s, --services INTEGER   Number of services to create
  -g, --groups INTEGER     Number of groups to create
  -p, --probability FLOAT  Probability of users being member of a
                           collaboration and services being connected to a
                           collaboration  [default: 0.5]
  --help                   Show this message and exit.
  ```