### PR TITLE
Hotfix revision e7e7dd87f94c

### DIFF
--- a/server/migrations/versions/e7e7dd87f94c_scim_token_encryption.py
+++ b/server/migrations/versions/e7e7dd87f94c_scim_token_encryption.py
@@ -33,7 +33,9 @@ def encrypt_secret(encryption_key: str, plain_secret: str, context: dict) -> str
 
 
 def upgrade():
-    config_file_location = os.environ.get("CONFIG", "config/config.yml")
+    rel_config_file_location = os.environ.get("CONFIG", "config/config.yml")
+    script_dir = os.path.dirname(__file__)
+    config_file_location = os.path.join(script_dir, "..", "..", rel_config_file_location)
     file = f"{config_file_location}"
     with open(file) as f:
         config = munchify(yaml.load(f.read(), Loader=yaml.FullLoader))


### PR DESCRIPTION
## Hotfix revision e7e7dd87f94c

### Bug
When following the README, the server is started as a Python module from the root directory of the project. With an empty database, all the alembic revisions are applied, but when upgrading to e7e7dd87f94c, the config file is read from the location set in the CONFIG env variable, namely `config/test_config.yml`. Since the server is started from the root of the project, the actual location of the config file is `server/config/test_config.yml`. When running the alembic upgrade manually with `alembic -c migrations/alembic.ini upgrade head`, it does work, because that command needs to be run inside the server folder. This feels like a workaround, but maybe I am missing something?

### Temporary solution
My quickfix for now is to take the file location of the revision, and navigate back to the config file from there, so that it works independent of the current working directory. I realise this is still somewhat of a hotfix, because ideally, you don't want to make the alembic revisions so dependent on the folder structure, which can change over time. 

### Testing
- [x] Tested upgrade with `PROFILE=local ALLOW_MOCK_USER_API=1 CONFIG=config/test_config.yml python -m server` and an empty database
- [x] Tested upgrade with `alembic -c migrations/alembic.ini upgrade head` and an empty database

### Suggestions for longterm solution
It seems the config file is correctly read with the CONFIG env variable in the `__main__.py` with the help of the `read_file` function in `tools.py`, maybe that will work too in the revision? But I did not have time to figure that out yet.