### PR TITLE
Fix error on empty cert dir

### DIFF
--- a/misc/container-init-pre.sh
+++ b/misc/container-init-pre.sh
@@ -38,6 +38,7 @@ fi
 # and copy any certs that are provided
 if [ -d "$CONF_DIR/cert" ]
 then
+    shopt -s nullglob dotglob
     mkdir -p /usr/local/share/ca-certificates
     for cert in "$CONF_DIR/cert"/*
     do


### PR DESCRIPTION
https://stackoverflow.com/questions/30043225/looping-on-empty-directory-content-in-bash

This problem popped up when migrating the sram-deploy roles to openconext-deploy. In our old aws infrastructure, we used these ca certificates to facilitate backchannel communication between SBS and other SRAM containers, in the new SURFConext infrastructure, these certificates become obsolete because the backchannel communication happens either locally via the docker bridge or via the load balancer. Therefore, the ca-certificates directory could be empty, which this bash script can't handle. This fixes that problem.