### PR TITLE
Add checks for nonexisting CO or service in connection request

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Make sure you point to the `sbs` database by changing the `database.uri` from `"
 
 Run alembic on your sbs database by running `alembic -c migrations/alembic.ini upgrade head` inside the server (alembic points to the correct default, see `server/migrations/alembic.ini`).
 
+To fill the test database as well, `sqlalchemy.url = mysql+mysqldb://sbs:sbs@127.0.0.1/sbs?charset=utf8mb4` to `sqlalchemy.url = mysql+mysqldb://sbs:sbs@127.0.0.1/sbs_test?charset=utf8mb4` just once, apply the alembic upgrade head command again, and revert the change back so that it points to sbs again.
+
 Now you can start the server from the project root (so outside the server folder):
 
 ```bash
@@ -99,7 +101,7 @@ The GUI can be started with:
 
 ```bash
 cd client
-yarn start
+yarn dev
 ```
 
 To create a GUI production build:

--- a/server/api/service_connection_request.py
+++ b/server/api/service_connection_request.py
@@ -137,11 +137,11 @@ def delete_service_request_connection(service_connection_request_id):
     return delete(ServiceConnectionRequest, service_connection_request_id)
 
 
-@service_connection_request_api.route("/", methods=["POST"], strict_slashes=False)
-@json_endpoint
-def request_service_connection():
+@service_connection_request_api.route("/", methods=["POST"], strict_slashes=False) # type: ignore
+@json_endpoint # type: ignore
+def request_service_connection() -> tuple[object, int]:
     data = current_request.get_json()
-    service = db.session.get(Service, int(data["service_id"]))            
+    service = db.session.get(Service, int(data["service_id"]))
     collaboration = db.session.get(Collaboration, int(data["collaboration_id"]))
 
     if not collaboration:
@@ -164,13 +164,13 @@ def request_service_connection():
     return {}, 201
 
 
-def request_new_service_connection(collaboration, message, service, user):
+def request_new_service_connection(collaboration, message, service, user) -> None:
     existing_request = ServiceConnectionRequest.query \
         .filter(ServiceConnectionRequest.collaboration_id == collaboration.id) \
         .filter(ServiceConnectionRequest.service_id == service.id) \
         .filter(ServiceConnectionRequest.status == STATUS_OPEN) \
         .all()
-    
+
     if existing_request:
         raise BadRequest(f"A service connection request already exists between {service.name} and {collaboration.name}")
     pending_organisation_approval = collaboration.organisation.service_connection_requires_approval

--- a/server/api/service_connection_request.py
+++ b/server/api/service_connection_request.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, request as current_request, current_app, g as request_context
 from sqlalchemy.orm import contains_eager, load_only
-from werkzeug.exceptions import BadRequest, Forbidden
+from werkzeug.exceptions import BadRequest, Forbidden, NotFound
 
 from server.api.base import json_endpoint, emit_socket
 from server.api.collaborations_services import connect_service_collaboration
@@ -141,8 +141,11 @@ def delete_service_request_connection(service_connection_request_id):
 @json_endpoint
 def request_service_connection():
     data = current_request.get_json()
-    service = db.session.get(Service, int(data["service_id"]))
+    service = db.session.get(Service, int(data["service_id"]))            
     collaboration = db.session.get(Collaboration, int(data["collaboration_id"]))
+
+    if not collaboration:
+        raise NotFound(f"The collaboration with id {data["collaboration_id"]} does not exist")
 
     confirm_collaboration_admin(collaboration.id)
 
@@ -164,6 +167,7 @@ def request_new_service_connection(collaboration, message, service, user):
         .filter(ServiceConnectionRequest.service_id == service.id) \
         .filter(ServiceConnectionRequest.status == STATUS_OPEN) \
         .all()
+    
     if existing_request:
         raise BadRequest(f"A service connection request already exists between {service.name} and {collaboration.name}")
     pending_organisation_approval = collaboration.organisation.service_connection_requires_approval

--- a/server/api/service_connection_request.py
+++ b/server/api/service_connection_request.py
@@ -147,6 +147,9 @@ def request_service_connection():
     if not collaboration:
         raise NotFound(f"The collaboration with id {data["collaboration_id"]} does not exist")
 
+    if not service:
+        raise NotFound(f"The service with id {data["service_id"]} does not exist")
+
     confirm_collaboration_admin(collaboration.id)
 
     user = db.session.get(User, current_user_id())

--- a/server/api/service_connection_request.py
+++ b/server/api/service_connection_request.py
@@ -137,8 +137,8 @@ def delete_service_request_connection(service_connection_request_id):
     return delete(ServiceConnectionRequest, service_connection_request_id)
 
 
-@service_connection_request_api.route("/", methods=["POST"], strict_slashes=False) # type: ignore
-@json_endpoint # type: ignore
+@service_connection_request_api.route("/", methods=["POST"], strict_slashes=False)  # type: ignore
+@json_endpoint  # type: ignore
 def request_service_connection() -> tuple[object, int]:
     data = current_request.get_json()
     service = db.session.get(Service, int(data["service_id"]))

--- a/server/api/service_connection_request.py
+++ b/server/api/service_connection_request.py
@@ -141,14 +141,17 @@ def delete_service_request_connection(service_connection_request_id):
 @json_endpoint  # type: ignore
 def request_service_connection() -> tuple[object, int]:
     data = current_request.get_json()
-    service = db.session.get(Service, int(data["service_id"]))
-    collaboration = db.session.get(Collaboration, int(data["collaboration_id"]))
+    service_id = int(data["service_id"])
+    service = db.session.get(Service, service_id)
+
+    collaboration_id = int(data["collaboration_id"])
+    collaboration = db.session.get(Collaboration, collaboration_id)
 
     if not collaboration:
-        raise NotFound(f"The collaboration with id {data["collaboration_id"]} does not exist")
+        raise NotFound(f"The collaboration with id {collaboration_id} does not exist")
 
     if not service:
-        raise NotFound(f"The service with id {data["service_id"]} does not exist")
+        raise NotFound(f"The service with id {service_id} does not exist")
 
     confirm_collaboration_admin(collaboration.id)
 

--- a/server/api/service_connection_request.py
+++ b/server/api/service_connection_request.py
@@ -165,7 +165,7 @@ def request_new_service_connection(collaboration, message, service, user):
         .filter(ServiceConnectionRequest.status == STATUS_OPEN) \
         .all()
     if existing_request:
-        raise BadRequest(f"outstanding_service_connection_request: {service.name} and {collaboration.name}")
+        raise BadRequest(f"A service connection request already exists between {service.name} and {collaboration.name}")
     pending_organisation_approval = collaboration.organisation.service_connection_requires_approval
     service_connection_request = ServiceConnectionRequest(message=message,
                                                           hash=generate_token(),

--- a/server/swagger/public/paths/connect_collaboration_service.yml
+++ b/server/swagger/public/paths/connect_collaboration_service.yml
@@ -48,5 +48,6 @@ responses:
     schema:
       $ref: '/swagger/components/responses/Forbidden.yaml'
   404:
+    description: Either the service or the collaboration does not exist
     schema:
       $ref: '/swagger/components/responses/NotFound.yaml'

--- a/server/test/api/test_service_connection_request.py
+++ b/server/test/api/test_service_connection_request.py
@@ -97,7 +97,6 @@ class TestServiceConnectionRequest(AbstractTest):
         self.post("/api/service_connection_requests", body=data, with_basic_auth=False, response_status_code=403)
 
     def test_service_connection_request_for_nonexistent_co(self):
-        
         ### Arrange
         service = self.find_entity_by_name(Service, service_ssh_name)
         self.login("urn:sarah")
@@ -111,7 +110,7 @@ class TestServiceConnectionRequest(AbstractTest):
         result = self.post("/api/service_connection_requests", body=data, with_basic_auth=False, response_status_code=404)
 
         ### Assert
-        self.assertTrue("404" in result["message"])
+        self.assertTrue("NotFound" in result["message"])
 
     def test_service_connection_request_for_nonexistent_service(self):
         pass

--- a/server/test/api/test_service_connection_request.py
+++ b/server/test/api/test_service_connection_request.py
@@ -97,7 +97,8 @@ class TestServiceConnectionRequest(AbstractTest):
         self.post("/api/service_connection_requests", body=data, with_basic_auth=False, response_status_code=403)
 
     def test_service_connection_request_for_nonexistent_co(self):
-        ### Arrange
+
+        # Arrange
         service = self.find_entity_by_name(Service, service_ssh_name)
         self.login("urn:sarah")
         data = {
@@ -106,14 +107,15 @@ class TestServiceConnectionRequest(AbstractTest):
             "message": "Pretty please"
         }
 
-        ### Act
+        # Act
         result = self.post("/api/service_connection_requests", body=data, with_basic_auth=False, response_status_code=404)
 
-        ### Assert
+        # Assert
         self.assertTrue("NotFound" in result["message"])
 
     def test_service_connection_request_for_nonexistent_service(self):
-        ### Arrange
+
+        # Arrange
         collaboration = self.find_entity_by_name(Collaboration, co_research_name)
         self.login("urn:sarah")
         data = {
@@ -122,15 +124,15 @@ class TestServiceConnectionRequest(AbstractTest):
             "message": "Pretty please"
         }
 
-        ### Act
+        # Act
         result = self.post("/api/service_connection_requests", body=data, with_basic_auth=False, response_status_code=404)
 
-        ### Assert
+        # Assert
         self.assertTrue("NotFound" in result["message"])
 
     def test_existing_service_connection_request(self):
 
-        ### Arrange
+        # Arrange
         collaboration = self.find_entity_by_name(Collaboration, co_research_name)
         service = self.find_entity_by_name(Service, service_ssh_name)
 
@@ -149,10 +151,10 @@ class TestServiceConnectionRequest(AbstractTest):
             "message": "Pretty please"
         }
 
-        ### Act
+        # Act
         result = self.post("/api/service_connection_requests", body=data, with_basic_auth=False, response_status_code=400)
 
-        ### Assert
+        # Assert
         self.assertTrue("A service connection request already exists between" in result["message"])
 
     def test_approve_service_connection_request_not_allowed(self):

--- a/server/test/api/test_service_connection_request.py
+++ b/server/test/api/test_service_connection_request.py
@@ -84,7 +84,7 @@ class TestServiceConnectionRequest(AbstractTest):
             mail_msg = outbox[0]
             self.assertListEqual(["betty@uuc.org", "james@example.org"], sorted(mail_msg.to))
 
-    def test_service_connection_request_by_member(self):
+    def test_service_connection_request_by_member_not_allowed(self):
         collaboration = self.find_entity_by_name(Collaboration, co_ai_computing_name)
         service = self.find_entity_by_name(Service, service_cloud_name)
         service_id = service.id
@@ -96,10 +96,31 @@ class TestServiceConnectionRequest(AbstractTest):
         }
         self.post("/api/service_connection_requests", body=data, with_basic_auth=False, response_status_code=403)
 
+    def test_service_connection_request_for_nonexistent_co(self):
+        
+        ### Arrange
+        service = self.find_entity_by_name(Service, service_ssh_name)
+        self.login("urn:sarah")
+        data = {
+            "collaboration_id": "1234",
+            "service_id": service.id,
+            "message": "Pretty please"
+        }
+
+        ### Act
+        result = self.post("/api/service_connection_requests", body=data, with_basic_auth=False, response_status_code=404)
+
+        ### Assert
+        self.assertTrue("404" in result["message"])
+
+    def test_service_connection_request_for_nonexistent_service(self):
+        pass
+
     def test_existing_service_connection_request(self):
 
         ### Arrange
         collaboration = self.find_entity_by_name(Collaboration, co_research_name)
+        print(collaboration.id)
         service = self.find_entity_by_name(Service, service_ssh_name)
 
         existing_request = ServiceConnectionRequest.query \
@@ -118,10 +139,10 @@ class TestServiceConnectionRequest(AbstractTest):
         }
 
         ### Act
-        res = self.post("/api/service_connection_requests", body=data, with_basic_auth=False, response_status_code=400)
+        result = self.post("/api/service_connection_requests", body=data, with_basic_auth=False, response_status_code=400)
 
         ### Assert
-        self.assertTrue("A service connection request already exists between" in res["message"])
+        self.assertTrue("A service connection request already exists between" in result["message"])
 
     def test_approve_service_connection_request_not_allowed(self):
         service = self.find_entity_by_name(Service, service_ssh_name)

--- a/server/test/api/test_service_connection_request.py
+++ b/server/test/api/test_service_connection_request.py
@@ -113,13 +113,25 @@ class TestServiceConnectionRequest(AbstractTest):
         self.assertTrue("NotFound" in result["message"])
 
     def test_service_connection_request_for_nonexistent_service(self):
-        pass
+        ### Arrange
+        collaboration = self.find_entity_by_name(Collaboration, co_research_name)
+        self.login("urn:sarah")
+        data = {
+            "collaboration_id": collaboration.id,
+            "service_id": "1234",
+            "message": "Pretty please"
+        }
+
+        ### Act
+        result = self.post("/api/service_connection_requests", body=data, with_basic_auth=False, response_status_code=404)
+
+        ### Assert
+        self.assertTrue("NotFound" in result["message"])
 
     def test_existing_service_connection_request(self):
 
         ### Arrange
         collaboration = self.find_entity_by_name(Collaboration, co_research_name)
-        print(collaboration.id)
         service = self.find_entity_by_name(Service, service_ssh_name)
 
         existing_request = ServiceConnectionRequest.query \

--- a/server/test/api/test_service_connection_request.py
+++ b/server/test/api/test_service_connection_request.py
@@ -1,6 +1,7 @@
 import uuid
 
 from server.db.db import db
+from server.db.defaults import STATUS_OPEN
 from server.db.domain import Collaboration, Service, ServiceConnectionRequest
 from server.test.abstract_test import AbstractTest
 from server.test.seed import service_connection_request_ssh_hash, co_research_name, service_wiki_name, \
@@ -96,8 +97,18 @@ class TestServiceConnectionRequest(AbstractTest):
         self.post("/api/service_connection_requests", body=data, with_basic_auth=False, response_status_code=403)
 
     def test_existing_service_connection_request(self):
+
+        ### Arrange
         collaboration = self.find_entity_by_name(Collaboration, co_research_name)
         service = self.find_entity_by_name(Service, service_ssh_name)
+
+        existing_request = ServiceConnectionRequest.query \
+            .filter(ServiceConnectionRequest.collaboration_id == collaboration.id) \
+            .filter(ServiceConnectionRequest.service_id == service.id) \
+            .filter(ServiceConnectionRequest.status == STATUS_OPEN) \
+            .first()
+
+        self.assertTrue(existing_request)
 
         self.login("urn:sarah")
         data = {
@@ -105,8 +116,12 @@ class TestServiceConnectionRequest(AbstractTest):
             "service_id": service.id,
             "message": "Pretty please"
         }
+
+        ### Act
         res = self.post("/api/service_connection_requests", body=data, with_basic_auth=False, response_status_code=400)
-        self.assertTrue("outstanding_service_connection_request" in res["message"])
+
+        ### Assert
+        self.assertTrue("A service connection request already exists between" in res["message"])
 
     def test_approve_service_connection_request_not_allowed(self):
         service = self.find_entity_by_name(Service, service_ssh_name)


### PR DESCRIPTION
We get a lot of errors in our sram inbox, caused by a Snellius cronjob:

```
Hi,

Bad news. An error occurred in at 2026-05-12 05:47 for user Organisation API call SURF:

Traceback (most recent call last):
  File "/opt/sbs/sbs/server/api/base.py", line 200, in wrapper
    body, status = f(*args, **kwargs)
                   ^^^^^^^^^^^^^^^^^^
  File "/opt/sbs/sbs/server/api/collaborations_services.py", line 179, in connect_collaboration_service_api
    return _do_connect_collaboration_service_api(organisation, co_identifier, collaborations)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/sbs/sbs/server/api/collaborations_services.py", line 86, in _do_connect_collaboration_service_api
    request_new_service_connection(collaboration, None, service, admins[0])
  File "/opt/sbs/sbs/server/api/service_connection_request.py", line 168, in request_new_service_connection
    raise BadRequest(f"outstanding_service_connection_request: {service.name} and {collaboration.name}")
werkzeug.exceptions.BadRequest: 400 Bad Request: BadRequest: https://sram.surf.nl/api/collaborations_services/v1/connect_collaboration_service/c746867f-2219-46a3-bb0e-4d31b7c0fd04. IP: 145.38.200.251, 10.0.1.20. outstanding_service_connection_request: Snellius and cba-cart-stefanwo
```

A `400` seems to be expected when posting another connection request while an open one still exists, but while investigating this issue it became clear that you can post a connection request for a nonexistent co without a problem. This fixes that, it should return a 404.