### PR TITLE
Fix e2e aup test

### DIFF
--- a/e2e-tests-mocked/package.json
+++ b/e2e-tests-mocked/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "test": "SBS_LOCAL_BASE_URL=http://localhost:3000 playwright test",
     "test:ui": "SBS_LOCAL_BASE_URL=http://localhost:3000 playwright test --ui",
+    "test:debug": "SBS_LOCAL_BASE_URL=http://localhost:3000 playwright test --debug --project=chromium",
     "postinstall": "playwright install"
   },
   "dependencies": {}

--- a/e2e-tests-mocked/tests/aup/aup.spec.ts
+++ b/e2e-tests-mocked/tests/aup/aup.spec.ts
@@ -86,7 +86,7 @@ test.describe('Local AUP happy flow', () => {
     expect(agreeResponse.status()).toBe(201);
     expect(refreshResponse.status()).toBe(200);
 
-    await expect(page).toHaveURL(`${baseURL}/welcome`);
+    await expect(page).toHaveURL(`${baseURL}/aup-accepted`);
     await expect(page.getByRole('heading', { name: /^Hi Playwright/ })).toBeHidden();
   });
 });

--- a/e2e-tests-mocked/tests/aup/aup.spec.ts
+++ b/e2e-tests-mocked/tests/aup/aup.spec.ts
@@ -26,8 +26,8 @@ async function mockAupApi(page: Page) {
     headers: jsonHeaders,
     body: JSON.stringify({
       local: false,
-      continue_eduteams_redirect_uri: 'http://localhost',
-      continue_eb_redirect_uri: 'http://localhost',
+      continue_eduteams_redirect_uri: baseURL,
+      continue_eb_redirect_uri: baseURL,
     }),
   }));
   await page.route('**/api/aup/info', route => route.fulfill({
@@ -54,7 +54,7 @@ async function mockAupApi(page: Page) {
     return route.fulfill({
       status: 201,
       headers: jsonHeaders,
-      body: JSON.stringify({ location: `${baseURL}/aup-accepted` }),
+      body: JSON.stringify({ location: `${baseURL}/welcome` }),
     });
   });
 }
@@ -86,7 +86,7 @@ test.describe('Local AUP happy flow', () => {
     expect(agreeResponse.status()).toBe(201);
     expect(refreshResponse.status()).toBe(200);
 
-    await expect(page).toHaveURL(`${baseURL}/aup-accepted`);
+    await expect(page).toHaveURL(`${baseURL}/welcome`);
     await expect(page.getByRole('heading', { name: /^Hi Playwright/ })).toBeHidden();
   });
 });


### PR DESCRIPTION
On the local-dev the AUP e2e test failed. This is because there was a redirect url to a page that did not exist. The FE server in the CI runs a production build compared to locally the usual dev server.

In this PR i updated the mocked redirect-url as well as the expected url to an existing page `/welcome`, this makes the tests pass on local dev and in the CI