### PR TITLE
#1343 Upgrades jsondiffpatch and applies changes in imports and configs

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -19,7 +19,7 @@
         "immer": "^11.1.4",
         "isomorphic-dompurify": "^2.36.0",
         "js-cookie": "^3.0.5",
-        "jsondiffpatch": "^0.5.0",
+        "jsondiffpatch": "^0.7.6",
         "lodash.clonedeep": "^4.5.0",
         "lodash.debounce": "^4.0.8",
         "lodash.escape": "^4.0.1",

--- a/client/src/components/activity/Activity.jsx
+++ b/client/src/components/activity/Activity.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import I18n from "../../locale/I18n";
 import "./Activity.scss";
 import {DiffPatcher} from "jsondiffpatch";
-import "jsondiffpatch/dist/formatters-styles/html.css";
+import "jsondiffpatch/formatters/styles/html.css";
 import {escapeDeep, isEmpty} from "../../utils/Utils";
 import {pseudoIso} from "../../utils/Date";
 import {Pagination} from "@surfnet/sds";

--- a/client/src/components/history/History.jsx
+++ b/client/src/components/history/History.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import I18n from "../../locale/I18n";
 import "./History.scss";
-import "jsondiffpatch/dist/formatters-styles/html.css";
+import "jsondiffpatch/formatters/styles/html.css";
 import {auditLogsInfo, auditLogsMe} from "../../api";
 import {AppStore} from "../../stores/AppStore";
 import {getParameterByName} from "../../utils/QueryParameters";

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -19,17 +19,6 @@ export default defineConfig({
                 find: /^@surfnet\/sds$/,
                 replacement: '@surfnet/sds/esm/index.js',
             },
-            // JS: force browser-safe build
-            {
-                find: /^jsondiffpatch$/,
-                replacement: 'jsondiffpatch/dist/jsondiffpatch.umd.js',
-            },
-
-            // CSS: keep original path working
-            {
-                find: /^jsondiffpatch\/dist\/formatters-styles\/(.*)$/,
-                replacement: 'jsondiffpatch/dist/formatters-styles/$1',
-            },
         ],
     },
     plugins: [

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -292,6 +292,11 @@
   resolved "https://registry.yarnpkg.com/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz#798a33950d11226a0ebb6acafa60f5594424967f"
   integrity sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==
 
+"@dmsnell/diff-match-patch@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@dmsnell/diff-match-patch/-/diff-match-patch-1.1.0.tgz#5bac00243fa2583fa970d9865609f632dcd90e32"
+  integrity sha512-yejLPmM5pjsGvxS9gXablUSbInW7H976c/FJ4iQxWIm7/38xBySRemTPDe34lhg1gVLbJntX0+sH0jYfU+PN9A==
+
 "@emnapi/core@1.10.0":
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.10.0.tgz#380ccc8f2412ea22d1d972df7f8ee23a3b9c7467"
@@ -1513,14 +1518,6 @@ chai@^6.2.2:
   resolved "https://registry.yarnpkg.com/chai/-/chai-6.2.2.tgz#ae41b52c9aca87734505362717f3255facda360e"
   integrity sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==
 
-chalk@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
-  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
-
 chalk@^4.1.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
@@ -1819,11 +1816,6 @@ detect-libc@^2.0.3:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.1.2.tgz#689c5dcdc1900ef5583a4cb9f6d7b473742074ad"
   integrity sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==
-
-diff-match-patch@^1.0.0:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/diff-match-patch/-/diff-match-patch-1.0.5.tgz#abb584d5f10cd1196dfc55aa03701592ae3f7b37"
-  integrity sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==
 
 doctrine@^2.1.0:
   version "2.1.0"
@@ -3019,13 +3011,12 @@ json5@^2.1.2, json5@^2.2.3:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
-jsondiffpatch@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/jsondiffpatch/-/jsondiffpatch-0.5.0.tgz#f9795416022685a3ba7eced11a338c5cb0cf66f4"
-  integrity sha512-Quz3MvAwHxVYNXsOByL7xI5EB2WYOeFswqaHIA3qOK3isRWTxiplBEocmmru6XmxDB2L7jDNYtYA4FyimoAFEw==
+jsondiffpatch@^0.7.6:
+  version "0.7.6"
+  resolved "https://registry.yarnpkg.com/jsondiffpatch/-/jsondiffpatch-0.7.6.tgz#5b71221911ef1bc2725a42da66a4aea83ec7220a"
+  integrity sha512-zE9+AXFq+MkTolDor2Cw1nJzLC0aleqPkYf52Kb4Kn4mJcka/gFHpGI2JBVEJCfWOvBl0OoxZS+wuLdislQcqg==
   dependencies:
-    chalk "^3.0.0"
-    diff-match-patch "^1.0.0"
+    "@dmsnell/diff-match-patch" "^1.1.0"
 
 "jsx-ast-utils@^2.4.1 || ^3.0.0":
   version "3.3.5"


### PR DESCRIPTION
Upgrades jsondiffpatch and applies changes in imports and configs

The temporary fix in the vite config prevented the upgrade. The temporary solution is not applicable anymore as well