### PR TITLE
#2449 Prevent sorting when headers are hidden

### DIFF
--- a/client/src/components/redesign/entities/Entities.scss
+++ b/client/src/components/redesign/entities/Entities.scss
@@ -186,7 +186,7 @@
                 }
 
                 &.hide {
-                    color: white;
+                    visibility: hidden;
                     cursor: default;
                 }
 


### PR DESCRIPTION
#2449 Hiding colum instad of changing text color. This prevents the sorting to still work when clicking on that white space