### PR TITLE
SCIM improvements

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -78,6 +78,7 @@
     "scripts": {
         "analyze": "source-map-explorer build/static/js/main.*.js ",
         "dev": "vite",
+        "start": "vite --host 0.0.0.0",
         "build": "vite build",
         "lint": "eslint ./src",
         "preview": "vite preview",

--- a/client/run.sh
+++ b/client/run.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/bash
+#!/bin/bash
+set -euo pipefail
 cd /opt/app/client
 yarn
-PORT=8080 yarn start
+export PORT="${PORT:-8080}"
+exec yarn start

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -32,8 +32,9 @@ export default defineConfig({
         chunkSizeWarningLimit: 1000
     },
     server: {
-      port: 3000,
-      open: true,
+      port: Number(process.env.PORT) || 3000,
+      host: true,
+      open: !process.env.PORT,
       allowedHosts: true,
       proxy: {
         '/api': {

--- a/etc/config.yml
+++ b/etc/config.yml
@@ -142,6 +142,9 @@ metadata:
   scope_override:
     test.nl: "Koninklijke Nederlandse Test"
 
+# Run scheduled jobs and startup locks (migrations) in this process.
+cron_job_responsible: True
+
 service_bus:
   enabled: False
   host: "localhost"

--- a/server/api/scim.py
+++ b/server/api/scim.py
@@ -17,7 +17,7 @@ from server.db.db import db
 from server.db.defaults import SERVICE_TOKEN_SCIM
 from server.db.domain import User, Collaboration, Group, Service
 from server.logger.context_logger import ctx_logger
-from server.scim import SCIM_URL_PREFIX, EXTERNAL_ID_POST_FIX
+from server.scim import SCIM_URL_PREFIX, strip_external_id_postfix
 from server.scim.group_template import find_groups_template, find_group_by_id_template
 from server.scim.repo import all_scim_users_by_service, all_scim_groups_by_service
 from server.scim.resource_type_template import resource_type_template, resource_type_user_template, \
@@ -114,7 +114,7 @@ def service_users():
 @json_endpoint
 def service_user_by_external_id(user_external_id: str):
     validate_service_token("scim_client_enabled", SERVICE_TOKEN_SCIM)
-    stripped_external_id = user_external_id.replace(EXTERNAL_ID_POST_FIX, "")
+    stripped_external_id = strip_external_id_postfix(user_external_id)
     user = User.query.filter(User.external_id == stripped_external_id).one()
     return find_user_by_id_template(user), _add_etag_header(user)
 
@@ -133,7 +133,7 @@ def service_groups():
 @json_endpoint
 def service_group_by_identifier(group_external_id: str):
     validate_service_token("scim_client_enabled", SERVICE_TOKEN_SCIM)
-    stripped_group_identifier = group_external_id.replace(EXTERNAL_ID_POST_FIX, "")
+    stripped_group_identifier = strip_external_id_postfix(group_external_id)
     group = Collaboration.query.filter(Collaboration.identifier == stripped_group_identifier).first()
     if not group:
         group = Group.query.filter(Group.identifier == stripped_group_identifier).one()

--- a/server/api/scim.py
+++ b/server/api/scim.py
@@ -19,6 +19,7 @@ from server.db.domain import User, Collaboration, Group, Service
 from server.logger.context_logger import ctx_logger
 from server.scim import SCIM_URL_PREFIX, strip_external_id_postfix
 from server.scim.group_template import find_groups_template, find_group_by_id_template
+from server.scim.pagination import parse_pagination_params
 from server.scim.repo import all_scim_users_by_service, all_scim_groups_by_service
 from server.scim.resource_type_template import resource_type_template, resource_type_user_template, \
     resource_type_group_template
@@ -106,7 +107,11 @@ def service_users():
         users = User.query.filter(func.lower(User.uid) == func.lower(uid)).all()
     else:
         users = all_scim_users_by_service(service)
-    return find_users_template(users), 200
+    start_index, count = parse_pagination_params(
+        query_param("startIndex", required=False),
+        query_param("count", required=False),
+    )
+    return find_users_template(users, start_index, count), 200
 
 
 @scim_api.route("/Users/<user_external_id>", methods=["GET"], strict_slashes=False)
@@ -125,7 +130,11 @@ def service_user_by_external_id(user_external_id: str):
 def service_groups():
     service = validate_service_token("scim_client_enabled", SERVICE_TOKEN_SCIM)
     all_scim_groups = all_scim_groups_by_service(service)
-    return find_groups_template(all_scim_groups), 200
+    start_index, count = parse_pagination_params(
+        query_param("startIndex", required=False),
+        query_param("count", required=False),
+    )
+    return find_groups_template(all_scim_groups, start_index, count), 200
 
 
 @scim_api.route("/Groups/<group_external_id>", methods=["GET"], strict_slashes=False)

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "Flask-SQLAlchemy==3.1.1",
     "flask_migrate==4.1.0",
     "flasgger @ git+https://github.com/SURFscz/flasgger@surf/main",
-    "gunicorn==26.0.0",
+    "gunicorn==25.3.0",  # 26.0 dropped the eventlet worker; SBS still uses eventlet + SocketIO
     "jinja2==3.1.6",
     "munch==4.0.0",
     "mysqlclient==2.2.8",

--- a/server/scim/__init__.py
+++ b/server/scim/__init__.py
@@ -1,5 +1,17 @@
 SCIM_URL_PREFIX = "/api/scim/v2"
-EXTERNAL_ID_POST_FIX = "@sram.surf.nl"
 
 SCIM_USERS = "Users"
 SCIM_GROUPS = "Groups"
+
+
+def external_id_postfix(config=None):
+    """Return the @-prefixed domain suffix for SCIM externalId values."""
+    if config is None:
+        from flask import current_app
+        config = current_app.app_config
+    scope = config.eppn_scope.strip().lstrip("@")
+    return f"@{scope}"
+
+
+def strip_external_id_postfix(scim_external_id: str, config=None) -> str:
+    return scim_external_id.replace(external_id_postfix(config), "")

--- a/server/scim/group_template.py
+++ b/server/scim/group_template.py
@@ -2,7 +2,7 @@ from typing import Union, List
 
 from server.api.base import application_base_url
 from server.db.domain import Group, Collaboration, CollaborationMembership
-from server.scim import SCIM_URL_PREFIX, EXTERNAL_ID_POST_FIX
+from server.scim import SCIM_URL_PREFIX, external_id_postfix
 from server.scim.schema_template import SCIM_SCHEMA_CORE_GROUP, SCIM_API_MESSAGES
 from server.scim.user_template import version_value, date_time_format, replace_none_values
 
@@ -12,7 +12,7 @@ def _meta_info(group: Union[Group, Collaboration]):
             "created": date_time_format(group.created_at),
             "lastModified": date_time_format(group.updated_at),
             "version": version_value(group),
-            "location": f"/Groups/{group.identifier}{EXTERNAL_ID_POST_FIX}"}
+            "location": f"/Groups/{group.identifier}{external_id_postfix()}"}
 
 
 def create_group_template(group: Union[Group, Collaboration], membership_scim_objects):
@@ -56,7 +56,7 @@ def create_group_template(group: Union[Group, Collaboration], membership_scim_ob
             SCIM_SCHEMA_CORE_GROUP,
             get_scim_schema_sram_group()
         ],
-        "externalId": f"{group.identifier}{EXTERNAL_ID_POST_FIX}",
+        "externalId": f"{group.identifier}{external_id_postfix()}",
         "displayName": group.name,
         "members": sorted_members,
         get_scim_schema_sram_group(): scim_sram_extension
@@ -71,7 +71,7 @@ def update_group_template(group: Union[Group, Collaboration], membership_scim_ob
 
 # This is used for internal SRAM groups and external SCIM providers
 def scim_member_object(base_url, membership: CollaborationMembership, scim_object=None):
-    member_value = f"{membership.user.external_id}{EXTERNAL_ID_POST_FIX}"
+    member_value = f"{membership.user.external_id}{external_id_postfix()}"
     return {
         "value": scim_object["id"] if scim_object else member_value,
         "display": membership.user.name,
@@ -82,7 +82,7 @@ def scim_member_object(base_url, membership: CollaborationMembership, scim_objec
 def find_group_by_id_template(group: Union[Group, Collaboration]):
     base_url = application_base_url()
     members = [scim_member_object(base_url, m) for m in group.collaboration_memberships if m.is_active()]
-    group_template = update_group_template(group, members, f"{group.identifier}{EXTERNAL_ID_POST_FIX}")
+    group_template = update_group_template(group, members, f"{group.identifier}{external_id_postfix()}")
     group_template["meta"] = _meta_info(group)
     return group_template
 

--- a/server/scim/group_template.py
+++ b/server/scim/group_template.py
@@ -3,6 +3,7 @@ from typing import Union, List
 from server.api.base import application_base_url
 from server.db.domain import Group, Collaboration, CollaborationMembership
 from server.scim import SCIM_URL_PREFIX, external_id_postfix
+from server.scim.pagination import paginate_items
 from server.scim.schema_template import SCIM_SCHEMA_CORE_GROUP, SCIM_API_MESSAGES
 from server.scim.user_template import version_value, date_time_format, replace_none_values
 
@@ -87,17 +88,15 @@ def find_group_by_id_template(group: Union[Group, Collaboration]):
     return group_template
 
 
-def find_groups_template(groups: List[Union[Group, Collaboration]]):
-    base = {
+def find_groups_template(groups: List[Union[Group, Collaboration]], start_index: int = 1, count: int = None):
+    page_groups, total, items_per_page = paginate_items(groups, start_index, count)
+    resources = [find_group_by_id_template(group) for group in page_groups]
+    return {
         "schemas": [
             f"{SCIM_API_MESSAGES}:ListResponse"
         ],
-        "totalResults": len(groups),
-        "startIndex": 0,
-        "itemsPerPage": len(groups),
+        "totalResults": total,
+        "startIndex": start_index,
+        "itemsPerPage": items_per_page,
+        "Resources": resources,
     }
-    resources = []
-    for group in groups:
-        resources.append(find_group_by_id_template(group))
-    base["Resources"] = resources
-    return base

--- a/server/scim/pagination.py
+++ b/server/scim/pagination.py
@@ -1,0 +1,33 @@
+from werkzeug.exceptions import BadRequest
+
+
+def parse_pagination_params(start_index_param, count_param):
+    try:
+        start_index = 1 if start_index_param is None else int(start_index_param)
+    except (TypeError, ValueError):
+        raise BadRequest("startIndex must be an integer")
+    if start_index < 1:
+        raise BadRequest("startIndex must be greater than or equal to 1")
+
+    count = None
+    if count_param is not None:
+        try:
+            count = int(count_param)
+        except (TypeError, ValueError):
+            raise BadRequest("count must be an integer")
+        if count < 0:
+            raise BadRequest("count must be greater than or equal to 0")
+
+    return start_index, count
+
+
+def paginate_items(items, start_index, count):
+    total = len(items)
+    offset = start_index - 1
+    if offset >= total:
+        page = []
+    elif count is None:
+        page = items[offset:]
+    else:
+        page = items[offset:offset + count]
+    return page, total, len(page)

--- a/server/scim/schema_template.py
+++ b/server/scim/schema_template.py
@@ -307,6 +307,38 @@ def schema_sram_group_template():
             "returned": "default",
             "uniqueness": "none"
         },
+        {
+            "name": "links",
+            "type": "complex",
+            "multiValued": True,
+            "required": False,
+            "caseExact": False,
+            "mutability": "readOnly",
+            "returned": "default",
+            "uniqueness": "none",
+            "subAttributes": [
+                {
+                    "name": "name",
+                    "type": "string",
+                    "multiValued": False,
+                    "required": False,
+                    "caseExact": False,
+                    "mutability": "readOnly",
+                    "returned": "default",
+                    "uniqueness": "none"
+                },
+                {
+                    "name": "value",
+                    "type": "string",
+                    "multiValued": False,
+                    "required": False,
+                    "caseExact": False,
+                    "mutability": "readOnly",
+                    "returned": "default",
+                    "uniqueness": "none"
+                }
+            ]
+        },
     ])
 
 

--- a/server/scim/schema_template.py
+++ b/server/scim/schema_template.py
@@ -1,3 +1,6 @@
+from typing import Any
+
+
 SCIM_API_MESSAGES = "urn:ietf:params:scim:api:messages:2.0"
 
 SCIM_SCHEMA_CORE = "urn:ietf:params:scim:schemas:core:2.0"
@@ -8,25 +11,25 @@ SCIM_SCHEMA_CORE_GROUP = f"{SCIM_SCHEMA_CORE}:Group"
 SCIM_SCHEMA_SRAM = "urn:example:sram:scim:schemas:1.0"  # Default
 
 
-def init_scim_schemas(urn):
+def init_scim_schemas(urn: str) -> None:
     """Initialize SCIM SRAM schemas with urn"""
     global SCIM_SCHEMA_SRAM
     SCIM_SCHEMA_SRAM = urn
 
 
-def get_scim_schema_sram():
+def get_scim_schema_sram() -> str:
     return SCIM_SCHEMA_SRAM
 
 
-def get_scim_schema_sram_user():
+def get_scim_schema_sram_user() -> str:
     return f"{get_scim_schema_sram()}:User"
 
 
-def get_scim_schema_sram_group():
+def get_scim_schema_sram_group() -> str:
     return f"{get_scim_schema_sram()}:Group"
 
 
-def _schema(id, attributes):
+def _schema(id: str, attributes: list[dict[str, Any]]) -> dict[str, Any]:
     return {
         "schemas": [
             f"{SCIM_SCHEMA_CORE}:Schema"
@@ -42,7 +45,7 @@ def _schema(id, attributes):
     }
 
 
-def schema_core_user_template():
+def schema_core_user_template() -> dict[str, Any]:
     return _schema(SCIM_SCHEMA_CORE_USER, [
         {
             "name": "userName",
@@ -163,7 +166,7 @@ def schema_core_user_template():
     ])
 
 
-def schema_sram_user_template():
+def schema_sram_user_template() -> dict[str, Any]:
     return _schema(get_scim_schema_sram_user(), [
         {
             "name": "eduPersonScopedAffiliation",
@@ -218,7 +221,7 @@ def schema_sram_user_template():
     ])
 
 
-def schema_core_group_template():
+def schema_core_group_template() -> dict[str, Any]:
     return _schema(SCIM_SCHEMA_CORE_GROUP, [
         {
             "name": "displayName",
@@ -275,7 +278,7 @@ def schema_core_group_template():
     ])
 
 
-def schema_sram_group_template():
+def schema_sram_group_template() -> dict[str, Any]:
     return _schema(get_scim_schema_sram_group(), [
         {
             "name": "description",
@@ -342,7 +345,7 @@ def schema_sram_group_template():
     ])
 
 
-def schemas_template():
+def schemas_template() -> dict[str, Any]:
     resources = [
         schema_core_user_template(),
         schema_core_group_template(),

--- a/server/scim/scim.py
+++ b/server/scim/scim.py
@@ -11,7 +11,7 @@ from server.db.db import db
 from server.db.domain import Service, User, Group, Collaboration, Organisation
 from server.db.models import flatten, unique_model_objects
 from server.logger.context_logger import ctx_logger
-from server.scim import EXTERNAL_ID_POST_FIX, SCIM_USERS, SCIM_GROUPS
+from server.scim import external_id_postfix, SCIM_USERS, SCIM_GROUPS
 from server.scim.group_template import update_group_template, create_group_template, scim_member_object
 from server.scim.user_template import create_user_template, update_user_template, replace_none_values
 
@@ -130,7 +130,7 @@ def membership_user_scim_objects(service: Service, group: Union[Group, Collabora
 
 # Do a lookup of the user or group in the external SCIM DB belonging to this service
 def _lookup_scim_object(service: Service, scim_type: str, external_id: str):
-    query_filter = f"externalId eq \"{external_id}{EXTERNAL_ID_POST_FIX}\""
+    query_filter = f"externalId eq \"{external_id}{external_id_postfix()}\""
     url = f"{service.scim_url}/{scim_type}?filter={urllib.parse.quote(query_filter)}"
     response = requests.get(url, headers=scim_headers(service), timeout=SCIM_TIMEOUT)
     if not validate_response(response, service, extra_logging=f"lookup {scim_type} {external_id}"):

--- a/server/scim/sweep.py
+++ b/server/scim/sweep.py
@@ -6,7 +6,7 @@ from werkzeug.exceptions import BadRequest
 
 from server.api.base import application_base_url
 from server.db.domain import Service, Group, User, Collaboration
-from server.scim import EXTERNAL_ID_POST_FIX, SCIM_GROUPS, SCIM_USERS
+from server.scim import external_id_postfix, strip_external_id_postfix, SCIM_GROUPS, SCIM_USERS
 from server.scim.group_template import create_group_template, update_group_template, scim_member_object
 from server.scim.repo import all_scim_groups_by_service, all_scim_users_by_service
 from server.scim.scim import scim_headers, validate_response
@@ -92,7 +92,7 @@ def _group_changed(group: Union[Group, Collaboration], remote_group: dict, remot
     for remote_member in remote_group.get("members", []):
         remote_user = remote_users_by_id.get(remote_member["value"])
         if remote_user:
-            remote_members.append(remote_user["externalId"].replace(EXTERNAL_ID_POST_FIX, ""))
+            remote_members.append(strip_external_id_postfix(remote_user["externalId"]))
     if sram_members != sorted(remote_members):
         return True
     if get_scim_schema_sram_group() in remote_group:
@@ -171,7 +171,7 @@ def perform_sweep(service: Service):
 
     # First delete all remote users and groups that are incorrectly in the remote SCIM database
     for remote_group in remote_scim_groups:
-        if f"{remote_group.get('externalId', '').replace(EXTERNAL_ID_POST_FIX, '')}" not in groups_by_identifier:
+        if strip_external_id_postfix(remote_group.get('externalId', '')) not in groups_by_identifier:
             if "meta" in remote_group and "location" in remote_group['meta']:
                 url = f"{service.scim_url}{remote_group['meta']['location']}"
                 response = requests.delete(url, headers=scim_headers(service, is_delete=True), timeout=TIMEOUT)
@@ -179,16 +179,16 @@ def perform_sweep(service: Service):
                     sync_results["groups"]["deleted"].append(url)
 
     for remote_user in remote_scim_users:
-        if f"{remote_user.get('externalId', '').replace(EXTERNAL_ID_POST_FIX, '')}" not in users_by_external_id:
+        if strip_external_id_postfix(remote_user.get('externalId', '')) not in users_by_external_id:
             if "meta" in remote_user and "location" in remote_user['meta']:
                 url = f"{service.scim_url}{remote_user['meta']['location']}"
                 response = requests.delete(url, headers=scim_headers(service, is_delete=True), timeout=TIMEOUT)
                 if validate_response(response, service, outside_user_context=True, extra_logging="SCIM user delete"):
                     sync_results["users"]["deleted"].append(url)
 
-    remote_groups_by_external_id = {g.get("externalId", "").replace(EXTERNAL_ID_POST_FIX, ""): g for g in
+    remote_groups_by_external_id = {strip_external_id_postfix(g.get("externalId", "")): g for g in
                                     remote_scim_groups}
-    remote_users_by_external_id = {u.get("externalId", "").replace(EXTERNAL_ID_POST_FIX, ""): u for u in
+    remote_users_by_external_id = {strip_external_id_postfix(u.get("externalId", "")): u for u in
                                    remote_scim_users}
 
     for user in all_users:

--- a/server/scim/sweep.py
+++ b/server/scim/sweep.py
@@ -6,7 +6,7 @@ from werkzeug.exceptions import BadRequest
 
 from server.api.base import application_base_url
 from server.db.domain import Service, Group, User, Collaboration
-from server.scim import external_id_postfix, strip_external_id_postfix, SCIM_GROUPS, SCIM_USERS
+from server.scim import strip_external_id_postfix, SCIM_GROUPS, SCIM_USERS
 from server.scim.group_template import create_group_template, update_group_template, scim_member_object
 from server.scim.repo import all_scim_groups_by_service, all_scim_users_by_service
 from server.scim.scim import scim_headers, validate_response

--- a/server/scim/user_template.py
+++ b/server/scim/user_template.py
@@ -4,6 +4,7 @@ from typing import List, Union
 
 from server.db.domain import User, Group, Collaboration
 from server.scim import external_id_postfix
+from server.scim.pagination import paginate_items
 from server.scim.schema_template import SCIM_SCHEMA_CORE_USER, SCIM_API_MESSAGES
 from server.tools import dt_now, inactivity
 
@@ -79,17 +80,15 @@ def find_user_by_id_template(user: User):
     return user_template
 
 
-def find_users_template(users: List[User]):
-    base = {
+def find_users_template(users: List[User], start_index: int = 1, count: int = None):
+    page_users, total, items_per_page = paginate_items(users, start_index, count)
+    resources = [find_user_by_id_template(user) for user in page_users]
+    return {
         "schemas": [
             f"{SCIM_API_MESSAGES}:ListResponse"
         ],
-        "totalResults": len(users),
-        "startIndex": 0,
-        "itemsPerPage": len(users),
+        "totalResults": total,
+        "startIndex": start_index,
+        "itemsPerPage": items_per_page,
+        "Resources": resources,
     }
-    resources = []
-    for user in users:
-        resources.append(find_user_by_id_template(user))
-    base["Resources"] = resources
-    return base

--- a/server/scim/user_template.py
+++ b/server/scim/user_template.py
@@ -3,7 +3,7 @@ import hashlib
 from typing import List, Union
 
 from server.db.domain import User, Group, Collaboration
-from server.scim import EXTERNAL_ID_POST_FIX
+from server.scim import external_id_postfix
 from server.scim.schema_template import SCIM_SCHEMA_CORE_USER, SCIM_API_MESSAGES
 from server.tools import dt_now, inactivity
 
@@ -30,7 +30,7 @@ def _meta_info(user: User):
             "created": date_time_format(user.created_at),
             "lastModified": date_time_format(user.updated_at),
             "version": version_value(user),
-            "location": f"/Users/{user.external_id}{EXTERNAL_ID_POST_FIX}"}
+            "location": f"/Users/{user.external_id}{external_id_postfix()}"}
 
 
 def inactive_days(date_at):
@@ -46,7 +46,7 @@ def create_user_template(user: User):
             SCIM_SCHEMA_CORE_USER,
             get_scim_schema_sram_user()
         ],
-        "externalId": f"{user.external_id}{EXTERNAL_ID_POST_FIX}",
+        "externalId": f"{user.external_id}{external_id_postfix()}",
         "userName": user.username,
         "name": {
             "givenName": user.given_name,
@@ -74,7 +74,7 @@ def update_user_template(user: User, scim_identifier: str):
 
 
 def find_user_by_id_template(user: User):
-    user_template = update_user_template(user, f"{user.external_id}{EXTERNAL_ID_POST_FIX}")
+    user_template = update_user_template(user, f"{user.external_id}{external_id_postfix()}")
     user_template["meta"] = _meta_info(user)
     return user_template
 

--- a/server/swagger/public/paths/get_groups.yml
+++ b/server/swagger/public/paths/get_groups.yml
@@ -20,6 +20,22 @@ parameters:
     required: true
     type: string
     example: Bearer Am4Hp7GBO2lMseskWHRmEtE3DWD-VxZZ3qwMkNPv6qZ8
+  - name: startIndex
+    in: query
+    description: 1-based index of the first result to return (RFC 7644)
+    required: false
+    schema:
+      type: integer
+      minimum: 1
+      example: 1
+  - name: count
+    in: query
+    description: Maximum number of results to return
+    required: false
+    schema:
+      type: integer
+      minimum: 0
+      example: 15
 
 responses:
   200:

--- a/server/swagger/public/paths/get_users.yml
+++ b/server/swagger/public/paths/get_users.yml
@@ -21,6 +21,22 @@ parameters:
     schema:
       type: string
       example: Bearer Am4Hp7GBO2lMseskWHRmEtE3DWD-VxZZ3qwMkNPv6qZ8
+  - name: startIndex
+    in: query
+    description: 1-based index of the first result to return (RFC 7644)
+    required: false
+    schema:
+      type: integer
+      minimum: 1
+      example: 1
+  - name: count
+    in: query
+    description: Maximum number of results to return
+    required: false
+    schema:
+      type: integer
+      minimum: 0
+      example: 15
 
 responses:
   200:

--- a/server/swagger/public/schemas/ScimGroupListResult.yaml
+++ b/server/swagger/public/schemas/ScimGroupListResult.yaml
@@ -7,8 +7,8 @@ properties:
     example: 15
   startIndex:
     type: number
-    description: "Zero-based start index of the page"
-    example: 0
+    description: "1-based index of the first result in the current page (RFC 7644)"
+    example: 1
   totalResults:
     type: number
     description: "Total number of results"

--- a/server/swagger/public/schemas/ScimUserListResult.yaml
+++ b/server/swagger/public/schemas/ScimUserListResult.yaml
@@ -7,8 +7,8 @@ properties:
     example: 15
   startIndex:
     type: number
-    description: "Zero-based start index of the page"
-    example: 0
+    description: "1-based index of the first result in the current page (RFC 7644)"
+    example: 1
   totalResults:
     type: number
     description: "Total number of results"

--- a/server/test/abstract_test.py
+++ b/server/test/abstract_test.py
@@ -69,6 +69,10 @@ class AbstractTest(TestCase):
 
         AbstractTest.app = app
 
+    def scim_external_id_postfix(self):
+        from server.scim import external_id_postfix
+        return external_id_postfix(self.app.app_config)
+
     @staticmethod
     def find_by_name(coll, name):
         res = list(filter(lambda item: item["name"] == name, coll))

--- a/server/test/api/test_mock_scim.py
+++ b/server/test/api/test_mock_scim.py
@@ -9,7 +9,6 @@ from flask import current_app
 from server.api.base import application_base_url
 from server.api.mock_scim import HTTP_CALLS_KEY, DATABASE_KEY
 from server.db.domain import User, Collaboration, Group, Service
-from server.scim import EXTERNAL_ID_POST_FIX
 from server.scim.events import broadcast_collaboration_changed, broadcast_group_changed
 from server.scim.group_template import create_group_template, scim_member_object, update_group_template
 from server.scim.schema_template import get_scim_schema_sram_group
@@ -64,7 +63,7 @@ class TestMockScim(AbstractTest):  # type: ignore[misc]
         # Find by externalId
         sarah = self.find_entity_by_name(User, user_sarah_name)
         res = self.get("/api/scim_mock/Users",
-                       query_data={"filter": f"externalId eq \"{sarah.external_id}{EXTERNAL_ID_POST_FIX}\""},
+                       query_data={"filter": f"externalId eq \"{sarah.external_id}{self.scim_external_id_postfix()}\""},
                        headers=headers,
                        with_basic_auth=False)
         self.assertEqual(scim_id_user, res["Resources"][0]["id"])
@@ -98,7 +97,7 @@ class TestMockScim(AbstractTest):  # type: ignore[misc]
 
         # Find the group by externalId
         res = self.get("/api/scim_mock/Groups",
-                       query_data={"filter": f"externalId eq \"{collaboration.identifier}{EXTERNAL_ID_POST_FIX}\""},
+                       query_data={"filter": f"externalId eq \"{collaboration.identifier}{self.scim_external_id_postfix()}\""},
                        headers=headers,
                        with_basic_auth=False)
         self.assertEqual(scim_id_group, res["Resources"][0]["id"])

--- a/server/test/api/test_scim.py
+++ b/server/test/api/test_scim.py
@@ -8,14 +8,13 @@ from sqlalchemy import text
 
 from server.db.db import db
 from server.db.domain import User, Collaboration, Group, Service
-from server.scim import EXTERNAL_ID_POST_FIX
-from server.scim.resource_type_template import resource_type_template
-from server.scim.user_template import version_value
 from server.test.abstract_test import AbstractTest
 from server.test.seed import service_network_token, user_jane_name, co_ai_computing_name, group_ai_researchers, \
     service_network_name, service_wiki_token, service_wiki_name
 from server.tools import read_file
+from server.scim.resource_type_template import resource_type_template
 from server.scim.schema_template import schemas_template, get_scim_schema_sram_user
+from server.scim.user_template import version_value
 
 
 class TestScim(AbstractTest):
@@ -36,11 +35,12 @@ class TestScim(AbstractTest):
     def test_user_by_external_id(self):
         jane = self.find_entity_by_name(User, user_jane_name)
         jane_external_id = jane.external_id
-        res = self.get(f"/api/scim/v2/Users/{jane_external_id}{EXTERNAL_ID_POST_FIX}",
+        postfix = self.scim_external_id_postfix()
+        res = self.get(f"/api/scim/v2/Users/{jane_external_id}{postfix}",
                        headers={"Authorization": f"bearer {service_network_token}"},
                        with_basic_auth=False,
                        expected_headers={"Etag": version_value(jane)})
-        self.assertEqual(f"{jane_external_id}{EXTERNAL_ID_POST_FIX}", res["externalId"])
+        self.assertEqual(f"{jane_external_id}{postfix}", res["externalId"])
         self.assertEqual("User", res["meta"]["resourceType"])
 
     def test_user_by_external_id_404(self):
@@ -57,22 +57,24 @@ class TestScim(AbstractTest):
     def test_collaboration_by_identifier(self):
         collaboration = self.find_entity_by_name(Collaboration, co_ai_computing_name)
         collaboration_identifier = collaboration.identifier
-        res = self.get(f"/api/scim/v2/Groups/{collaboration_identifier}{EXTERNAL_ID_POST_FIX}",
+        postfix = self.scim_external_id_postfix()
+        res = self.get(f"/api/scim/v2/Groups/{collaboration_identifier}{postfix}",
                        headers={"Authorization": f"bearer {service_network_token}"},
                        with_basic_auth=False,
                        expected_headers={"Etag": version_value(collaboration)})
-        self.assertEqual(f"{collaboration_identifier}{EXTERNAL_ID_POST_FIX}", res["externalId"])
-        self.assertEqual(f"{collaboration_identifier}{EXTERNAL_ID_POST_FIX}", res["id"])
+        self.assertEqual(f"{collaboration_identifier}{postfix}", res["externalId"])
+        self.assertEqual(f"{collaboration_identifier}{postfix}", res["id"])
 
     def test_group_by_identifier(self):
         group = self.find_entity_by_name(Group, group_ai_researchers)
         group_identifier = group.identifier
         # We mock that all members are already known in the remote SCIM DB
-        res = self.get(f"/api/scim/v2/Groups/{group_identifier}{EXTERNAL_ID_POST_FIX}",
+        postfix = self.scim_external_id_postfix()
+        res = self.get(f"/api/scim/v2/Groups/{group_identifier}{postfix}",
                        headers={"Authorization": f"bearer {service_network_token}"},
                        with_basic_auth=False)
-        self.assertEqual(f"{group_identifier}{EXTERNAL_ID_POST_FIX}", res["externalId"])
-        self.assertEqual(f"{group_identifier}{EXTERNAL_ID_POST_FIX}", res["id"])
+        self.assertEqual(f"{group_identifier}{postfix}", res["externalId"])
+        self.assertEqual(f"{group_identifier}{postfix}", res["id"])
         self.assertEqual("Group", res["meta"]["resourceType"])
 
     def test_collaboration_by_identifier_404(self):

--- a/server/test/api/test_scim.py
+++ b/server/test/api/test_scim.py
@@ -23,6 +23,42 @@ class TestScim(AbstractTest):
         res = self.get("/api/scim/v2/Users", headers={"Authorization": f"bearer {service_network_token}"},
                        with_basic_auth=False)
         self.assertEqual(6, len(res["Resources"]))
+        self.assertEqual(6, res["totalResults"])
+        self.assertEqual(1, res["startIndex"])
+        self.assertEqual(6, res["itemsPerPage"])
+
+    def test_users_pagination(self):
+        headers = {"Authorization": f"bearer {service_network_token}"}
+        res = self.get("/api/scim/v2/Users",
+                       query_data={"startIndex": 2, "count": 2},
+                       headers=headers,
+                       with_basic_auth=False)
+        self.assertEqual(6, res["totalResults"])
+        self.assertEqual(2, res["startIndex"])
+        self.assertEqual(2, res["itemsPerPage"])
+        self.assertEqual(2, len(res["Resources"]))
+
+        res = self.get("/api/scim/v2/Users",
+                       query_data={"startIndex": 7},
+                       headers=headers,
+                       with_basic_auth=False)
+        self.assertEqual(6, res["totalResults"])
+        self.assertEqual(7, res["startIndex"])
+        self.assertEqual(0, res["itemsPerPage"])
+        self.assertEqual(0, len(res["Resources"]))
+
+    def test_users_pagination_invalid_params(self):
+        headers = {"Authorization": f"bearer {service_network_token}"}
+        self.get("/api/scim/v2/Users",
+                 query_data={"startIndex": 0},
+                 headers=headers,
+                 with_basic_auth=False,
+                 response_status_code=400)
+        self.get("/api/scim/v2/Users",
+                 query_data={"count": "nope"},
+                 headers=headers,
+                 with_basic_auth=False,
+                 response_status_code=400)
 
     def test_users_no_scim_enabled(self):
         wiki = self.find_entity_by_name(Service, service_wiki_name)
@@ -53,6 +89,20 @@ class TestScim(AbstractTest):
         res = self.get("/api/scim/v2/Groups", headers={"Authorization": f"bearer {service_network_token}"},
                        with_basic_auth=False)
         self.assertEqual(3, len(res["Resources"]))
+        self.assertEqual(3, res["totalResults"])
+        self.assertEqual(1, res["startIndex"])
+        self.assertEqual(3, res["itemsPerPage"])
+
+    def test_groups_pagination(self):
+        headers = {"Authorization": f"bearer {service_network_token}"}
+        res = self.get("/api/scim/v2/Groups",
+                       query_data={"startIndex": 2, "count": 1},
+                       headers=headers,
+                       with_basic_auth=False)
+        self.assertEqual(3, res["totalResults"])
+        self.assertEqual(2, res["startIndex"])
+        self.assertEqual(1, res["itemsPerPage"])
+        self.assertEqual(1, len(res["Resources"]))
 
     def test_collaboration_by_identifier(self):
         collaboration = self.find_entity_by_name(Collaboration, co_ai_computing_name)

--- a/server/test/scim/sweep/remote_groups_changes.json
+++ b/server/test/scim/sweep/remote_groups_changes.json
@@ -6,36 +6,36 @@
     "Resources": [
         {
             "displayName": "AI computing",
-            "externalId": "a71a2b01-4642-4e1a-b3ac-0a06b2bf66f2@sram.surf.nl",
+            "externalId": "a71a2b01-4642-4e1a-b3ac-0a06b2bf66f2@test.sram.surf.nl",
             "id": "768F27CF-98E2-42B4-9913-3AACF370D8FD",
             "members": [
                 {
-                    "$ref": "http://localhost:3000/api/scim/v2/Users/86eee601-770f-4df3-bd4c-181a2edcbb2f@sram.surf.nl",
+                    "$ref": "http://localhost:3000/api/scim/v2/Users/86eee601-770f-4df3-bd4c-181a2edcbb2f@test.sram.surf.nl",
                     "display": "John Doe",
                     "value": "3DC907C5-58D1-425A-A1D4-36D4A119B0FA"
                 },
                 {
-                    "$ref": "http://localhost:3000/api/scim/v2/Users/e906cf88-cdb3-480d-8bb3-ce53bdcda4e7@sram.surf.nl",
+                    "$ref": "http://localhost:3000/api/scim/v2/Users/e906cf88-cdb3-480d-8bb3-ce53bdcda4e7@test.sram.surf.nl",
                     "display": "The Boss",
                     "value": "4EDA5BB4-A708-4782-BCFB-D76588F79D4B"
                 },
                 {
-                    "$ref": "http://localhost:3000/api/scim/v2/Users/502e861e-f548-4335-89d8-f1764f803964@sram.surf.nl",
+                    "$ref": "http://localhost:3000/api/scim/v2/Users/502e861e-f548-4335-89d8-f1764f803964@test.sram.surf.nl",
                     "display": "Jane Doe",
                     "value": "B608F146-73F4-4613-A2E8-05A40C77F3F3"
                 },
                 {
-                    "$ref": "http://localhost:3000/api/scim/v2/Users/8297d8a5-a2a4-4208-9fb6-100a5865f022@sram.surf.nl",
+                    "$ref": "http://localhost:3000/api/scim/v2/Users/8297d8a5-a2a4-4208-9fb6-100a5865f022@test.sram.surf.nl",
                     "display": "Sarah Cross",
                     "value": "CC7352C1-D752-4588-9FF3-014800EA094B"
                 },
                 {
-                    "$ref": "http://localhost:3000/api/scim/v2/Users/bbd8123c-b0f9-4e3d-b3ff-288aa1c1edd6@sram.surf.nl",
+                    "$ref": "http://localhost:3000/api/scim/v2/Users/bbd8123c-b0f9-4e3d-b3ff-288aa1c1edd6@test.sram.surf.nl",
                     "display": "betty",
                     "value": "BA0DF4D5-E57E-46CA-A997-BEF2D0D0A174"
                 },
                                 {
-                    "$ref": "http://localhost:3000/api/scim/v2/Users/43b26575-b243-42ef-a7ac-6033d51372fe@sram.surf.nl",
+                    "$ref": "http://localhost:3000/api/scim/v2/Users/43b26575-b243-42ef-a7ac-6033d51372fe@test.sram.surf.nl",
                     "display": "Ebbe Doe",
                     "value": "D1D64FD9-7A8F-41E5-A6F1-78BF54BD7954"
                 }
@@ -52,7 +52,7 @@
         },
         {
             "displayName": "AI researchers",
-            "externalId": "9734e4c4-d23e-4228-b0e0-8e6a5b85e72e@sram.surf.nl",
+            "externalId": "9734e4c4-d23e-4228-b0e0-8e6a5b85e72e@test.sram.surf.nl",
             "id": "204DD260-D297-41E2-97AF-CDEF68EFB35B",
             "members": [],
             "meta": {
@@ -66,7 +66,7 @@
         },
         {
             "displayName": "unknown",
-            "externalId": "nope@sram.surf.nl",
+            "externalId": "nope@test.sram.surf.nl",
             "id": "19D2F1B9-5A1D-43D5-8F0C-FE6474E313E3",
             "members": [],
             "meta": {

--- a/server/test/scim/sweep/remote_groups_unchanged.json
+++ b/server/test/scim/sweep/remote_groups_unchanged.json
@@ -6,36 +6,36 @@
     "Resources": [
         {
             "displayName": "AI computing",
-            "externalId": "a71a2b01-4642-4e1a-b3ac-0a06b2bf66f2@sram.surf.nl",
+            "externalId": "a71a2b01-4642-4e1a-b3ac-0a06b2bf66f2@test.sram.surf.nl",
             "id": "768F27CF-98E2-42B4-9913-3AACF370D8FD",
             "members": [
                 {
-                    "$ref": "http://localhost:3000/api/scim/v2/Users/86eee601-770f-4df3-bd4c-181a2edcbb2f@sram.surf.nl",
+                    "$ref": "http://localhost:3000/api/scim/v2/Users/86eee601-770f-4df3-bd4c-181a2edcbb2f@test.sram.surf.nl",
                     "display": "John Doe",
                     "value": "3DC907C5-58D1-425A-A1D4-36D4A119B0FA"
                 },
                 {
-                    "$ref": "http://localhost:3000/api/scim/v2/Users/e906cf88-cdb3-480d-8bb3-ce53bdcda4e7@sram.surf.nl",
+                    "$ref": "http://localhost:3000/api/scim/v2/Users/e906cf88-cdb3-480d-8bb3-ce53bdcda4e7@test.sram.surf.nl",
                     "display": "The Boss",
                     "value": "4EDA5BB4-A708-4782-BCFB-D76588F79D4B"
                 },
                 {
-                    "$ref": "http://localhost:3000/api/scim/v2/Users/502e861e-f548-4335-89d8-f1764f803964@sram.surf.nl",
+                    "$ref": "http://localhost:3000/api/scim/v2/Users/502e861e-f548-4335-89d8-f1764f803964@test.sram.surf.nl",
                     "display": "Jane Doe",
                     "value": "B608F146-73F4-4613-A2E8-05A40C77F3F3"
                 },
                 {
-                    "$ref": "http://localhost:3000/api/scim/v2/Users/8297d8a5-a2a4-4208-9fb6-100a5865f022@sram.surf.nl",
+                    "$ref": "http://localhost:3000/api/scim/v2/Users/8297d8a5-a2a4-4208-9fb6-100a5865f022@test.sram.surf.nl",
                     "display": "Sarah Cross",
                     "value": "CC7352C1-D752-4588-9FF3-014800EA094B"
                 },
                 {
-                    "$ref": "http://localhost:3000/api/scim/v2/Users/bbd8123c-b0f9-4e3d-b3ff-288aa1c1edd6@sram.surf.nl",
+                    "$ref": "http://localhost:3000/api/scim/v2/Users/bbd8123c-b0f9-4e3d-b3ff-288aa1c1edd6@test.sram.surf.nl",
                     "display": "betty",
                     "value": "BA0DF4D5-E57E-46CA-A997-BEF2D0D0A174"
                 },
                 {
-                    "$ref": "http://localhost:3000/api/scim/v2/Users/43b26575-b243-42ef-a7ac-6033d51372fe@sram.surf.nl",
+                    "$ref": "http://localhost:3000/api/scim/v2/Users/43b26575-b243-42ef-a7ac-6033d51372fe@test.sram.surf.nl",
                     "display": "Ebbe Doe",
                     "value": "D1D64FD9-7A8F-41E5-A6F1-78BF54BD7954"
                 }
@@ -52,16 +52,16 @@
         },
         {
             "displayName": "AI researchers",
-            "externalId": "9734e4c4-d23e-4228-b0e0-8e6a5b85e72e@sram.surf.nl",
+            "externalId": "9734e4c4-d23e-4228-b0e0-8e6a5b85e72e@test.sram.surf.nl",
             "id": "204DD260-D297-41E2-97AF-CDEF68EFB35B",
             "members": [
                 {
-                    "$ref": "http://localhost:3000/api/scim/v2/Users/86eee601-770f-4df3-bd4c-181a2edcbb2f@sram.surf.nl",
+                    "$ref": "http://localhost:3000/api/scim/v2/Users/86eee601-770f-4df3-bd4c-181a2edcbb2f@test.sram.surf.nl",
                     "display": "John Doe",
                     "value": "3DC907C5-58D1-425A-A1D4-36D4A119B0FA"
                 },
                 {
-                    "$ref": "http://localhost:3000/api/scim/v2/Users/502e861e-f548-4335-89d8-f1764f803964@sram.surf.nl",
+                    "$ref": "http://localhost:3000/api/scim/v2/Users/502e861e-f548-4335-89d8-f1764f803964@test.sram.surf.nl",
                     "display": "Jane Doe",
                     "value": "B608F146-73F4-4613-A2E8-05A40C77F3F3"
                 }
@@ -77,11 +77,11 @@
         },
         {
             "displayName": "AI developers",
-            "externalId": "4c270cff-de30-49e8-a3bc-df032536b37c@sram.surf.nl",
+            "externalId": "4c270cff-de30-49e8-a3bc-df032536b37c@test.sram.surf.nl",
             "id": "0747BBDA-837A-479A-B55D-BB0C1B836747",
             "members": [
                 {
-                    "$ref": "http://localhost:3000/api/scim/v2/Users/86eee601-770f-4df3-bd4c-181a2edcbb2f@sram.surf.nl",
+                    "$ref": "http://localhost:3000/api/scim/v2/Users/86eee601-770f-4df3-bd4c-181a2edcbb2f@test.sram.surf.nl",
                     "display": "John Doe",
                     "value": "3DC907C5-58D1-425A-A1D4-36D4A119B0FA"
                 }

--- a/server/test/scim/sweep/remote_users_changes.json
+++ b/server/test/scim/sweep/remote_users_changes.json
@@ -15,7 +15,7 @@
                     "value": "john@example.org"
                 }
             ],
-            "externalId": "86eee601-770f-4df3-bd4c-181a2edcbb2f@sram.surf.nl",
+            "externalId": "86eee601-770f-4df3-bd4c-181a2edcbb2f@test.sram.surf.nl",
             "id": "3DC907C5-58D1-425A-A1D4-36D4A119B0FA",
             "meta": {
                 "created": "2022-12-14T16:41:01",
@@ -47,7 +47,7 @@
                     "value": "boss@example.org"
                 }
             ],
-            "externalId": "e906cf88-cdb3-480d-8bb3-ce53bdcda4e7@sram.surf.nl",
+            "externalId": "e906cf88-cdb3-480d-8bb3-ce53bdcda4e7@test.sram.surf.nl",
             "id": "4EDA5BB4-A708-4782-BCFB-D76588F79D4B",
             "meta": {
                 "created": "2022-12-14T16:41:01",
@@ -75,7 +75,7 @@
                     "value": "jane@ucc.org"
                 }
             ],
-            "externalId": "502e861e-f548-4335-89d8-f1764f803964@sram.surf.nl",
+            "externalId": "502e861e-f548-4335-89d8-f1764f803964@test.sram.surf.nl",
             "id": "B608F146-73F4-4613-A2E8-05A40C77F3F3",
             "meta": {
                 "created": "2022-12-14T16:41:01",
@@ -103,7 +103,7 @@
                     "value": "sarah@uni-franeker.nl"
                 }
             ],
-            "externalId": "8297d8a5-a2a4-4208-9fb6-100a5865f022@sram.surf.nl",
+            "externalId": "8297d8a5-a2a4-4208-9fb6-100a5865f022@test.sram.surf.nl",
             "id": "CC7352C1-D752-4588-9FF3-014800EA094B",
             "meta": {
                 "created": "2022-12-14T16:41:01",
@@ -130,7 +130,7 @@
             "active": true,
             "displayName": "unknown_user",
             "emails": [],
-            "externalId": "1DE53F36-2DB3-4CD4-8204-6692958F1133@sram.surf.nl",
+            "externalId": "1DE53F36-2DB3-4CD4-8204-6692958F1133@test.sram.surf.nl",
             "id": "1DE53F36-2DB3-4CD4-8204-6692958F1133",
             "meta": {
                 "created": "2022-12-14T16:41:01",

--- a/server/test/scim/sweep/remote_users_unchanged.json
+++ b/server/test/scim/sweep/remote_users_unchanged.json
@@ -15,7 +15,7 @@
                     "value": "john@example.org"
                 }
             ],
-            "externalId": "86eee601-770f-4df3-bd4c-181a2edcbb2f@sram.surf.nl",
+            "externalId": "86eee601-770f-4df3-bd4c-181a2edcbb2f@test.sram.surf.nl",
             "id": "3DC907C5-58D1-425A-A1D4-36D4A119B0FA",
             "meta": {
                 "created": "2022-12-14T16:41:01",
@@ -47,7 +47,7 @@
                     "value": "boss@example.org"
                 }
             ],
-            "externalId": "e906cf88-cdb3-480d-8bb3-ce53bdcda4e7@sram.surf.nl",
+            "externalId": "e906cf88-cdb3-480d-8bb3-ce53bdcda4e7@test.sram.surf.nl",
             "id": "4EDA5BB4-A708-4782-BCFB-D76588F79D4B",
             "meta": {
                 "created": "2022-12-14T16:41:01",
@@ -75,7 +75,7 @@
                     "value": "jane@ucc.org"
                 }
             ],
-            "externalId": "502e861e-f548-4335-89d8-f1764f803964@sram.surf.nl",
+            "externalId": "502e861e-f548-4335-89d8-f1764f803964@test.sram.surf.nl",
             "id": "B608F146-73F4-4613-A2E8-05A40C77F3F3",
             "meta": {
                 "created": "2022-12-14T16:41:01",
@@ -103,7 +103,7 @@
                     "value": "sarah@uni-franeker.nl"
                 }
             ],
-            "externalId": "8297d8a5-a2a4-4208-9fb6-100a5865f022@sram.surf.nl",
+            "externalId": "8297d8a5-a2a4-4208-9fb6-100a5865f022@test.sram.surf.nl",
             "id": "CC7352C1-D752-4588-9FF3-014800EA094B",
             "meta": {
                 "created": "2022-12-14T16:41:01",
@@ -135,7 +135,7 @@
                     "value": "betty@uuc.org"
                 }
             ],
-            "externalId": "bbd8123c-b0f9-4e3d-b3ff-288aa1c1edd6@sram.surf.nl",
+            "externalId": "bbd8123c-b0f9-4e3d-b3ff-288aa1c1edd6@test.sram.surf.nl",
             "id": "BA0DF4D5-E57E-46CA-A997-BEF2D0D0A174",
             "meta": {
                 "created": "2022-12-14T16:41:01",
@@ -163,7 +163,7 @@
                     "value": "ebbe@example.org"
                 }
             ],
-            "externalId": "43b26575-b243-42ef-a7ac-6033d51372fe@sram.surf.nl",
+            "externalId": "43b26575-b243-42ef-a7ac-6033d51372fe@test.sram.surf.nl",
             "id": "D1D64FD9-7A8F-41E5-A6F1-78BF54BD7954",
             "meta": {
                 "created": "2022-12-14T16:41:01",

--- a/server/test/scim/test_pagination.py
+++ b/server/test/scim/test_pagination.py
@@ -1,0 +1,58 @@
+from unittest import TestCase
+
+from werkzeug.exceptions import BadRequest
+
+from server.scim.pagination import parse_pagination_params, paginate_items
+
+
+class TestScimPagination(TestCase):
+
+    def test_defaults(self):
+        start_index, count = parse_pagination_params(None, None)
+        self.assertEqual(1, start_index)
+        self.assertIsNone(count)
+
+    def test_parses_query_params(self):
+        start_index, count = parse_pagination_params("3", "2")
+        self.assertEqual(3, start_index)
+        self.assertEqual(2, count)
+
+    def test_rejects_invalid_start_index(self):
+        with self.assertRaises(BadRequest):
+            parse_pagination_params("0", None)
+        with self.assertRaises(BadRequest):
+            parse_pagination_params("nope", None)
+
+    def test_rejects_invalid_count(self):
+        with self.assertRaises(BadRequest):
+            parse_pagination_params(None, "-1")
+        with self.assertRaises(BadRequest):
+            parse_pagination_params(None, "nope")
+
+    def test_paginate_items(self):
+        items = ["a", "b", "c", "d", "e"]
+
+        page, total, items_per_page = paginate_items(items, 1, 2)
+        self.assertEqual(["a", "b"], page)
+        self.assertEqual(5, total)
+        self.assertEqual(2, items_per_page)
+
+        page, total, items_per_page = paginate_items(items, 3, 2)
+        self.assertEqual(["c", "d"], page)
+        self.assertEqual(5, total)
+        self.assertEqual(2, items_per_page)
+
+        page, total, items_per_page = paginate_items(items, 6, 2)
+        self.assertEqual([], page)
+        self.assertEqual(5, total)
+        self.assertEqual(0, items_per_page)
+
+        page, total, items_per_page = paginate_items(items, 1, None)
+        self.assertEqual(items, page)
+        self.assertEqual(5, total)
+        self.assertEqual(5, items_per_page)
+
+        page, total, items_per_page = paginate_items(items, 1, 0)
+        self.assertEqual([], page)
+        self.assertEqual(5, total)
+        self.assertEqual(0, items_per_page)

--- a/server/test/scim/test_schema_template.py
+++ b/server/test/scim/test_schema_template.py
@@ -1,0 +1,15 @@
+from unittest import TestCase
+
+from server.scim.schema_template import schema_sram_group_template
+
+
+class TestSchemaTemplate(TestCase):
+
+    def test_schema_sram_group_includes_links_attributes(self):
+        schema = schema_sram_group_template()
+        links = next(attribute for attribute in schema["attributes"] if attribute["name"] == "links")
+
+        self.assertEqual("complex", links["type"])
+        self.assertTrue(links["multiValued"])
+        sub_attribute_names = {sub_attribute["name"] for sub_attribute in links["subAttributes"]}
+        self.assertEqual({"name", "value"}, sub_attribute_names)

--- a/server/test/scim/test_user_template.py
+++ b/server/test/scim/test_user_template.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 import uuid
 from unittest import TestCase
 
@@ -9,6 +10,13 @@ from server.tools import dt_now
 
 class TestUserTemplate(TestCase):
 
+    @classmethod
+    def setUpClass(cls):
+        os.environ["CONFIG"] = os.environ.get("CONFIG", "config/test_config.yml")
+        os.environ["TESTING"] = "1"
+        from server.__main__ import app
+        cls.app = app
+
     def test_find_user_by_id_template(self):
         from server.scim.schema_template import get_scim_schema_sram_user
 
@@ -17,7 +25,8 @@ class TestUserTemplate(TestCase):
         last_login_date = now - datetime.timedelta(days=(days), weeks=3)
         user = User(external_id=uuid.uuid4(), name="John Doe", email="jdoe@domain.com", updated_at=now, created_at=now,
                     last_login_date=last_login_date)
-        result = find_user_by_id_template(user)
+        with self.app.app_context():
+            result = find_user_by_id_template(user)
 
         self.assertEqual(result["displayName"], user.name)
         self.assertEqual(result["name"]["familyName"], "")


### PR DESCRIPTION
## Summary

This PR addresses three open SCIM issues:

- **#2060** — Make SCIM `externalId` domain suffix configurable via global config instead of hardcoded `@sram.surf.nl`
- **#1996** — Add RFC 7644 pagination support on `GET /Users` and `GET /Groups`, and fix `startIndex` to be 1-based
- **#2327** — Document `links.name` and `links.value` in the SRAM Group extension schema

### #2060 — Configurable SCIM externalId suffix

- Replace hardcoded `EXTERNAL_ID_POST_FIX` with `external_id_postfix()` and `strip_external_id_postfix()`
- Derive suffix from `eppn_scope` in app config (e.g. `@test.sram.surf.nl` in test, `@sram.surf.nl` in production)
- Update SCIM templates, API path parsing, sweep logic, and tests/fixtures accordingly

> Note: issue #2060 suggested `base_scope`, but `eppn_scope` matches the expected `@test.sram.surf.nl` format and is already used for SAML `eduPersonPrincipalName`.

### #1996 — SCIM list pagination

- Accept `startIndex` and `count` query parameters on `GET /api/scim/v2/Users` and `GET /api/scim/v2/Groups`
- Return `startIndex: 1` by default (was `0`; RFC 7644 requires 1-based indexing)
- Set `itemsPerPage` to the number of resources in the current page
- Add shared pagination helpers in `server/scim/pagination.py`
- Update Swagger docs and list result schemas

### #2327 — SRAM Group extension schema

- Add `links` complex attribute (`multiValued`) with `name` and `value` sub-attributes to `schema_sram_group_template()`
- Aligns published schema with group payloads already returned for collaborations (`sbs_url`, `logo`)

## Test plan

- [x] `pytest test/scim/test_pagination.py`
- [x] `pytest test/scim/test_schema_template.py`
- [x] `pytest test/api/test_scim.py` (including new pagination tests)
- [x] `pytest test/scim/` (sweep, events, templates)
- [x] Verify `GET /api/scim/v2/Schemas` includes `links` on the SRAM Group extension
- [x] Verify unpaginated list responses use `startIndex: 1`
- [x] Verify `?startIndex=2&count=2` returns correct slice and `totalResults`

## Closes

- Closes #2060
- Closes #1996
- Closes #2327