### PR TITLE
Group pip and npm PRs in one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,11 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    groups:
+      all-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   # Maintain dependencies for server
   - package-ecosystem: "pip"
@@ -20,3 +25,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    groups:
+      all-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Om onze lijst van PRs niet te laten overstromen (ook in de slack notifications) worden hiermee alle npm en pip dependabot PRs gebundeld.

Dit is ongetest, de code review is om te kijken of het er goed uit ziet en of het is wat we willen.